### PR TITLE
:pill: Fix Azure repo cloning

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "env"]
-	path = env
-	url = https://gitlab.com/nhsuk/dotenv.git

--- a/README.md
+++ b/README.md
@@ -27,27 +27,18 @@ That is hosted [here](https://connecting-to-services.herokuapp.com/)
 
 ## Environment variables
 
-Environment variables are loaded by
-[dotenv](https://www.npmjs.com/package/dotenv). If the value already
-exists within the environment that will be used. If not, the values in a dot
-file (`.env`) will be used.
-If there is no file, a warning will be issued when the application
-attempts to start.
+Environment variables are expected to be managed by the environment in which
+the application is being run. This is best practice as described by
+[twelve-factor](https://12factor.net/config).
 
-The `.env` file is managed via
-[git-submodule](https://git-scm.com/docs/git-submodule). In order to activate
-the submodule, once the repo has been cloned the following commands need
-to be executed:
+In order to protect the application from starting up without the required
+env vars in place [require-environment-variables](https://www.npmjs.com/package/require-environment-variables)
+is used to check all are present as part of the application start-up. If
+an env var is not found the application will fail to start and an appropriate
+message will be displayed.
 
-```
-git submodule init
-git submodule update
-```
 
-This will clone the submodule into the main repo and update it to the
-latest version. Future changes to the submodule can be pulled into the repo
-by running the update command.
+## FAQ
 
-Using submodules for managing environment variables is only used in developer
-environments. Other environments, specifically the hosting environments use
-a different mechanism for acquiring environment variables.
+* Is the application failing to start?
+> Ensure all expected environment variables are available within the environment

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "body-parser": "^1.13.3",
     "compression": "^1.5.2",
     "cookie-parser": "^1.3.3",
-    "dotenv": "^2.0.0",
     "express": "^4.13.3",
     "json-query": "^2.1.0",
     "moment": "^2.14.1",

--- a/server.js
+++ b/server.js
@@ -1,13 +1,11 @@
 const express = require('express');
 const config = require('./config/config');
 const configExpress = require('./config/express');
-const dotenv = require('dotenv');
 const requireEnv = require('require-environment-variables');
 
 const app = express();
 
 module.exports = (() => {
-  dotenv.config({ path: './env/.env' });
   requireEnv(['NHSCHOICES_SYNDICATION_APIKEY']);
   requireEnv(['NHSCHOICES_SYNDICATION_BASEURL']);
   configExpress(app, config);


### PR DESCRIPTION
Azure deployments are breaking because it doesn't have access to the GitLab repo. There are 2 steps involved in fixing it:
* Add the deployment key to the GitLab repo
* Update the submodule so it is requested over SSH rather than https (which means the deployment key will work, as opposed to having to send `username:password`)

I originally thought (see below) the vars in the env would be overridden by the `.env` file vars but this is not the case
> We will never modify any environment variables that have already been set

https://www.npmjs.com/package/dotenv#what-happens-to-environment-variables-that-were-already-set

However, this has got me thinking about the whether handling the env vars via submodules is a good idea. This is the second thing that has had to be dealt with differently due to the approach (the other being the ignoring of submodules in Travis).

Some of the original reasons for taking this approach was to:
* have an automated setup mechanism for development environments
* have a central place where working vars are stored
* other things I've forgotten about

If the submodule was removed the repo can still live and contain development versions of the vars for reference so no loss there. Having an automated setup for development environments - well that could just be a case of accepting that the environment variables need to available. Which does take a little bit of remembering but can be included in the `README.md`. A benefit of doing that would be that the `dotenv` package could be removed and all environments would be using the same mechanism.

Thoughts?

~~This does mean the Azure deployments are now going to be using the env vars from the repo which is the same as the development environment but no other environment i.e. CI, Heroku. This is not ideal.~~

~~Whether as part of this change or another one, the way of handling env vars need to be brought back to be consistent. Looking at the [docs](https://www.npmjs.com/package/dotenv) there are other ways to load env vars e.g. start the app with the file which would be something we could do just for development and let all other environments use the env vars they have.~~

~~Some thought required. I think having another look at https://12factor.net/config might be a good idea.~~