### PR TITLE
:accept: Make cookie message dynamic

### DIFF
--- a/.bithoundrc
+++ b/.bithoundrc
@@ -1,0 +1,58 @@
+{
+  "ignore": [
+    "**/deps/**",
+    "**/node_modules/**",
+    "**/thirdparty/**",
+    "**/third_party/**",
+    "**/vendor/**",
+    "**/**-min-**",
+    "**/**-min.**",
+    "**/**.min.**",
+    "**/**jquery.?(ui|effects)-*.*.?(*).?(cs|j)s",
+    "**/**jquery-*.*.?(*).?(cs|j)s",
+    "**/prototype?(*).js",
+    "**/mootools*.*.*.js",
+    "**/dojo.js",
+    "**/MochiKit.js",
+    "**/yahoo-*.js",
+    "**/yui*.js",
+    "**/ckeditor*.js",
+    "**/tiny_mce*.js",
+    "**/tiny_mce/?(langs|plugins|themes|utils)/**",
+    "**/MathJax/**",
+    "**/shBrush*.js",
+    "**/shCore.js",
+    "**/shLegacy.js",
+    "**/modernizr.custom.?(*).js",
+    "**/knockout-*.*.*.debug.js",
+    "**/extjs/*.js",
+    "**/extjs/*.xml",
+    "**/extjs/*.txt",
+    "**/extjs/*.html",
+    "**/extjs/*.properties",
+    "**/extjs/.sencha",
+    "**/extjs/docs/**",
+    "**/extjs/builds/**",
+    "**/extjs/cmd/**",
+    "**/extjs/examples/**",
+    "**/extjs/locale/**",
+    "**/extjs/packages/**",
+    "**/extjs/plugins/**",
+    "**/extjs/resources/**",
+    "**/extjs/src/**",
+    "**/extjs/welcome/**",
+    "bower_components/**",
+    "**/assets/**"
+  ],
+  "test": [
+    "**/test/**",
+    "**/tests/**",
+    "**/spec/**",
+    "**/specs/**"
+  ],
+  "dependencies": {
+    "unused-ignores": [
+      "webpack"
+    ]
+  }
+}

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,2 @@
 coverage/
-public/js/tracking
+public/js/*

--- a/app/views/includes/foot.nunjucks
+++ b/app/views/includes/foot.nunjucks
@@ -1,0 +1,2 @@
+<script src="js/nhsuk.bundle.js" type="text/javascript"></script>
+

--- a/app/views/layout.nunjucks
+++ b/app/views/layout.nunjucks
@@ -27,6 +27,7 @@
   </head>
 
   <body>
+    <script>(function(d){d.className=d.className.replace(/\bno-js\b/,'js-enabled')})(document.documentElement);</script>
     <div class="skiplinks">
       <div class="skiplinks--inner">
         <a href="#content" class="skiplinks--link">Skip to main content</a>
@@ -80,5 +81,7 @@
     <footer role="contentinfo">
       {% include "includes/footer.nunjucks" %}
     </footer>
+
+    {% include "includes/foot.nunjucks" %}
   </body>
 </html>

--- a/assets/javascripts/modules/cookie-message.js
+++ b/assets/javascripts/modules/cookie-message.js
@@ -1,0 +1,44 @@
+/* global document */
+function setCookie(name, value, options = {}) {
+  let cookieString = `${name}=${value}; path=/`;
+
+  if (options.days) {
+    const date = new Date();
+    date.setTime(date.getTime() + (options.days * 24 * 60 * 60 * 1000));
+    cookieString = `${cookieString}; expires=${date.toGMTString()}`;
+  }
+
+  if (document.location.protocol === 'https:') {
+    cookieString = `${cookieString}; Secure`;
+  }
+
+  document.cookie = cookieString;
+}
+
+function getCookie(name) {
+  const nameEQ = `${name}=`;
+  const cookies = document.cookie.split(';');
+
+  for (let i = 0, len = cookies.length; i < len; i++) {
+    let cookie = cookies[i];
+
+    while (cookie.charAt(0) === ' ') {
+      cookie = cookie.substring(1, cookie.length);
+    }
+
+    if (cookie.indexOf(nameEQ) === 0) {
+      return decodeURIComponent(cookie.substring(nameEQ.length));
+    }
+  }
+
+  return null;
+}
+
+module.exports = (id) => {
+  const banner = document.getElementById(id);
+
+  if (banner && getCookie('nhsuk_seen_cookie_message') === null) {
+    banner.style.display = 'block';
+    setCookie('nhsuk_seen_cookie_message', 'yes', { days: 28 });
+  }
+};

--- a/assets/javascripts/nhsuk.js
+++ b/assets/javascripts/nhsuk.js
@@ -1,0 +1,3 @@
+const cookieMessage = require('./modules/cookie-message');
+
+cookieMessage('global-cookies-banner');

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "start": "node app.js",
     "lint": "eslint --ext .js,.json .",
     "test": "mocha --recursive test",
+    "webpack": "webpack",
     "watch-dev": "nodemon app.js",
     "watch-lint": "esw --watch .",
     "watch-test": "npm run test -- --watch --reporter min",
@@ -45,6 +46,7 @@
     "postcode": "^0.2.5",
     "require-environment-variables": "^1.1.2",
     "verror": "^1.6.1",
+    "webpack": "^1.13.2",
     "xml2js": "^0.4.16"
   },
   "devDependencies": {

--- a/public/js/nhsuk.bundle.js
+++ b/public/js/nhsuk.bundle.js
@@ -1,0 +1,110 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			exports: {},
+/******/ 			id: moduleId,
+/******/ 			loaded: false
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.loaded = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ function(module, exports, __webpack_require__) {
+
+	module.exports = __webpack_require__(1);
+
+
+/***/ },
+/* 1 */
+/***/ function(module, exports, __webpack_require__) {
+
+	const cookieMessage = __webpack_require__(2);
+
+	cookieMessage('global-cookies-banner');
+
+
+/***/ },
+/* 2 */
+/***/ function(module, exports) {
+
+	/* global document */
+	function setCookie(name, value, options = {}) {
+	  let cookieString = `${name}=${value}; path=/`;
+
+	  if (options.days) {
+	    const date = new Date();
+	    date.setTime(date.getTime() + (options.days * 24 * 60 * 60 * 1000));
+	    cookieString = `${cookieString}; expires=${date.toGMTString()}`;
+	  }
+
+	  if (document.location.protocol === 'https:') {
+	    cookieString = `${cookieString}; Secure`;
+	  }
+
+	  document.cookie = cookieString;
+	}
+
+	function getCookie(name) {
+	  const nameEQ = `${name}=`;
+	  const cookies = document.cookie.split(';');
+
+	  for (let i = 0, len = cookies.length; i < len; i++) {
+	    let cookie = cookies[i];
+
+	    while (cookie.charAt(0) === ' ') {
+	      cookie = cookie.substring(1, cookie.length);
+	    }
+
+	    if (cookie.indexOf(nameEQ) === 0) {
+	      return decodeURIComponent(cookie.substring(nameEQ.length));
+	    }
+	  }
+
+	  return null;
+	}
+
+	module.exports = (id) => {
+	  const banner = document.getElementById(id);
+
+	  if (banner && getCookie('nhsuk_seen_cookie_message') === null) {
+	    banner.style.display = 'block';
+	    setCookie('nhsuk_seen_cookie_message', 'yes', { days: 28 });
+	  }
+	};
+
+
+/***/ }
+/******/ ]);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  entry: {
+    nhsuk: [
+      './assets/javascripts/nhsuk.js',
+    ],
+  },
+
+  output: {
+    path: './public/js/',
+    filename: 'nhsuk.bundle.js',
+  },
+};


### PR DESCRIPTION
This change adds the functionality to have the cookie message be dynamic and inline with how it works on the beta site.

Additional work required:

* Have `nhsuk.bundle.js` not be committed to source control and have it generated as part of the deployment
* Add ability to have the file minimised for deployments in non-dev environments

This has been facilitated by https://www.npmjs.com/package/webpack which seems to be the 'better/more popular' version of things like https://www.npmjs.com/package/browserify and https://www.npmjs.com/package/requirejs

Fixes #50 