### PR TITLE
:rocket: Route for no rewriting

### DIFF
--- a/app/middleware/services.js
+++ b/app/middleware/services.js
@@ -108,8 +108,7 @@ function getPharmacyOpeningTimes(req, res, next) {
 }
 
 function renderServiceResults(req, res) {
-  const path = req.path.substring(1);
-  res.render(path);
+  res.render('results');
 }
 
 function sortByDistanceInKms(a, b) {
@@ -155,7 +154,7 @@ function prepareForRender(req, res, next) {
   let altResultsMessage = '';
 
   if (open) {
-    altResultsUrl = `results?location=${location}`;
+    altResultsUrl = `/symptoms/stomach-ache/results?location=${location}`;
     altResultsMessage = 'See all nearby places that can help, open or closed';
 
     serviceList =
@@ -167,7 +166,7 @@ function prepareForRender(req, res, next) {
         .slice(0, 2)
         .map(getDisplayValuesMapper(location));
   } else {
-    altResultsUrl = `results?location=${location}&open=true`;
+    altResultsUrl = `/symptoms/stomach-ache/results?location=${location}&open=true`;
     altResultsMessage = 'See only open places nearby';
 
     const tenClosestPlaces = req.pharmacyList

--- a/app/views/call-111.nunjucks
+++ b/app/views/call-111.nunjucks
@@ -9,5 +9,4 @@
 <p>
 <a class="button" href="http://www.nhs.uk/NHSEngland/AboutNHSservices/Emergencyandurgentcareservices/Pages/NHS-111.aspx">More information about NHS 111</a>
 </p>
-<!-- <p><a href="/stomach-ache-find-help">Go back</a>.</p> -->
 {% endblock %}

--- a/app/views/find-help.nunjucks
+++ b/app/views/find-help.nunjucks
@@ -1,8 +1,6 @@
 {% extends 'layout.nunjucks' %}
 
-{% block header %}
-Find a place that can help with
-{% endblock %}
+{% block header %}Find a place that can help with{% endblock %}
 
 {% block pageTitle %}Find a place that can help with{% endblock %}
 
@@ -15,7 +13,7 @@ Find a place that can help with
 {% endblock %}
 
 {% block content %}
-<form class="form" id="formname" method="get" action="/search">
+<form class="form" id="formname" method="get" action="/symptoms/stomach-ache/search">
   <div class="form-item-wrapper">
       <legend class="form-label-bold">Can you get there by yourself?</legend>
 
@@ -40,7 +38,7 @@ Find a place that can help with
     </div>
   </div>
   <p></p>
-  <p>If you are not looking for help, <a href="/stomach-ache">go back</a>.</p>
+  <p>If you are not looking for help, <a href="/symptoms/stomach-ache">go back</a>.</p>
 </form>
 
 {% endblock %}

--- a/app/views/includes/foot.nunjucks
+++ b/app/views/includes/foot.nunjucks
@@ -1,2 +1,2 @@
-<script src="js/nhsuk.bundle.js" type="text/javascript"></script>
+<script src="/js/nhsuk.bundle.js" type="text/javascript"></script>
 

--- a/app/views/index.nunjucks
+++ b/app/views/index.nunjucks
@@ -6,6 +6,6 @@
 
 {% block content %}
 <ul class="list-bullet">
-  <li><a href="/stomach-ache">Stomach Ache</a></li>
+  <li><a href="/symptoms/stomach-ache">Stomach Ache</a></li>
 </ul>
 {% endblock %}

--- a/app/views/results.nunjucks
+++ b/app/views/results.nunjucks
@@ -7,7 +7,7 @@
 {% block pageIntro %}Listed below are all the places nearby that could help you, showing if they are open or closed.{% endblock %}
 
 {% block content %}
-<a href="/search" class="back-to-previous">Back</a>
+<a href="/symptoms/stomach-ache/search" class="back-to-previous">Back</a>
 
     <table>
       <tbody>

--- a/app/views/stomach-ache.nunjucks
+++ b/app/views/stomach-ache.nunjucks
@@ -27,7 +27,7 @@ A stomach ache is a term often used to refer to cramps or a dull ache in the tum
 <p>Painkillers like paracetamol can help with your stomach ache but won’t stop any vomiting and diarrhoea. Find out more about <a href="http://www.nhs.uk/conditions/gastroenteritis/Pages/Introduction.aspx">treating vomiting and diarrhoea</a>.</p>
 
 <p>
-<a href="stomach-ache-find-help" class="button">Find an open pharmacy</a>
+<a href="/symptoms/stomach-ache/find-help" class="button">Find an open pharmacy</a>
 </p>
 
 <h2>If the symptoms persist or get worse</h2>

--- a/config/routes.js
+++ b/config/routes.js
@@ -10,7 +10,7 @@ router.get('/',
   }
 );
 
-router.get('/search',
+router.get('/symptoms/stomach-ache/search',
   (req, res) => {
     const query = req.query;
 
@@ -28,7 +28,7 @@ router.get('/search',
   }
 );
 
-router.get('/results',
+router.get('/symptoms/stomach-ache/results',
   validateLocation,
   urlUtils.urlForPharmacyPostcodeSearch,
   servicesMiddleware.getPharmacies,
@@ -37,10 +37,15 @@ router.get('/results',
   servicesMiddleware.renderServiceResults
 );
 
-router.get('/:view',
+router.get('/symptoms/stomach-ache/find-help',
   (req, res) => {
-    const view = req.params.view.toLowerCase();
-    res.render(view, {});
+    res.render('find-help');
+  }
+);
+
+router.get('/symptoms/stomach-ache',
+  (req, res) => {
+    res.render('stomach-ache');
   }
 );
 

--- a/test/integration/app.js
+++ b/test/integration/app.js
@@ -36,7 +36,7 @@ describe('The default page', () => {
 describe('The stomach ache page', () => {
   it('should contain content for stomach ache', (done) => {
     chai.request(server)
-      .get('/stomach-ache')
+      .get('/symptoms/stomach-ache')
       .end((err, res) => {
         checkHtmlResponse(err, res);
 
@@ -49,10 +49,26 @@ describe('The stomach ache page', () => {
   });
 });
 
+describe('The find help page', () => {
+  it('should contain content for finding help with stomach ache', (done) => {
+    chai.request(server)
+      .get('/symptoms/stomach-ache/find-help')
+      .end((err, res) => {
+        checkHtmlResponse(err, res);
+
+        const $ = cheerio.load(res.text);
+
+        expect($('.local-header--title').text())
+          .to.equal('Find a place that can help with');
+        done();
+      });
+  });
+});
+
 describe('The search page', () => {
   it('should provide a prompt to enter a postcode', (done) => {
     chai.request(server)
-      .get('/search')
+      .get('/symptoms/stomach-ache/search')
       .query({ able: 'true' })
       .end((err, res) => {
         checkHtmlResponse(err, res);
@@ -68,7 +84,7 @@ describe('The search page', () => {
   it('should return a call 111 page when people are not able to get there',
     (done) => {
       chai.request(server)
-        .get('/search')
+        .get('/symptoms/stomach-ache/search')
         .query({ able: 'false' })
         .end((err, res) => {
           checkHtmlResponse(err, res);
@@ -85,7 +101,7 @@ describe('The search page', () => {
 describe('The results routes', () => {
   let originalUrl = '';
   let originalApikey = '';
-  const resultsRoute = '/results';
+  const resultsRoute = '/symptoms/stomach-ache/results';
   const baseUrl = 'http://web.site';
   const apikey = 'secret';
   const validPostcode = 'AB123CD';
@@ -136,7 +152,7 @@ describe('The results routes', () => {
           // Some arbitary element to suggest there are 10 results
           expect($('.map-button').length).to.equal(10);
           expect($('.gotoservice-cta').attr('href'))
-            .to.equal(`results?location=${validPostcode}&open=true`);
+            .to.equal(`/symptoms/stomach-ache/results?location=${validPostcode}&open=true`);
           expect(postcodeSearchScope.isDone()).to.be.true;
           expect(overviewScope.isDone()).to.be.true;
           done();
@@ -173,7 +189,7 @@ describe('The results routes', () => {
           // Some arbitary element to suggest there are 2 results
           expect($('.map-button').length).to.equal(2);
           expect($('.gotoservice-cta').attr('href'))
-            .to.equal(`results?location=${validPostcode}`);
+            .to.equal(`/symptoms/stomach-ache/results?location=${validPostcode}`);
           expect(postcodeSearchScope.isDone()).to.be.true;
           expect(overviewScope.isDone()).to.be.true;
           done();


### PR DESCRIPTION
Setup the app to minimise the amount of route rewriting required. Just at the moment this means the 'home' page is `/symptoms/stomach-ache` rather than `/`. I've specifically not made the routes take the symptom as a variable as that can be done as the next symptom is added. And symptom is likely going to need to be variable as it could also be condition.

Fixes #69