### PR TITLE
:facepunch: Prevent future silent BitHound failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "node app.js",
-    "lint": "eslint --ext .js,.json .",
+    "lint": "eslint --ext .js,.json . && cat .bithoundrc | eslint --stdin --stdin-filename=f.json",
     "test": "mocha --recursive test",
     "watch-dev": "nodemon app.js",
     "watch-lint": "esw --watch .",


### PR DESCRIPTION
BitHound failed to ignore vendor files as it was silently borking
with a non valid json .bithoundrc file. Add this to prevent this
happening again.

The convoluted cat command is due to this: https://github.com/eslint/eslint/issues/4829