### PR TITLE
:high_brightness: Added only open results

### DIFF
--- a/app/lib/openingTimesParser.js
+++ b/app/lib/openingTimesParser.js
@@ -36,17 +36,11 @@ const parseOpeningTimesFromSyndicationXml = (openingTimesType, xml) => {
 
         openingTimesForType.daysOfWeek[0].dayOfWeek.forEach((item) => {
           const dayName = item.dayName[0].toLowerCase();
-          openingTimes[dayName] = {};
-          openingTimes[dayName] = {
-            times: [],
-          };
+          openingTimes[dayName] = [];
           item.timesSessions[0].timesSession.forEach((t) => {
             if (t.fromTime) {
               // session details are a time range
-              openingTimes[dayName].times.push({ fromTime: t.fromTime[0], toTime: t.toTime[0] });
-            } else {
-              // session details are text (e.g. closed)
-              openingTimes[dayName].times.push(t);
+              openingTimes[dayName].push({ opens: t.fromTime[0], closes: t.toTime[0] });
             }
           });
         });

--- a/app/middleware/getPharmacies.js
+++ b/app/middleware/getPharmacies.js
@@ -5,10 +5,12 @@ function getPharmacies(req, res, next) {
   const searchPoint = res.locals.coordinates;
   const geo = cache.get('geo');
 
-  const nearbyServices = pharmacies.nearby(searchPoint, geo);
+  const nearby = pharmacies.nearby(searchPoint, geo);
 
-  // eslint-disable-next-line no-param-reassign
-  res.locals.nearbyServices = nearbyServices;
+  /* eslint-disable no-param-reassign*/
+  res.locals.nearbyServices = nearby.nearbyServices;
+  res.locals.openServices = nearby.openServices;
+  /* eslint-enable no-param-reassign*/
   next();
 }
 

--- a/app/views/results-file.nunjucks
+++ b/app/views/results-file.nunjucks
@@ -21,7 +21,14 @@
 
 <div class="results u-border u-nomargin">
 
-{% for service in nearbyServices %}
+
+{% if open === 'true' %}
+  {% set services = openServices %}
+{% else %}
+  {% set services = nearbyServices %}
+{% endif %}
+
+{% for service in services %}
 <div class="grid-row grid-row--tabledisplay">
   <div class="column__one-half column__one-half--tablecell">
     <h2>{{ service.name }}</h2>

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "json-query": "^2.1.0",
     "memory-cache": "^0.1.6",
     "moment": "^2.14.1",
-    "moment-opening-times": "git+https://github.com/nhsuk/moment-opening-times.git",
+    "moment-opening-times": "git://github.com/nhsuk/moment-opening-times.git#feature/change-opening-times-format",
     "morgan": "^1.6.1",
     "ngeohash": "^0.6.0",
     "nunjucks": "^2.4.2",

--- a/test/unit/lib/openingTimesParser.js
+++ b/test/unit/lib/openingTimesParser.js
@@ -13,15 +13,15 @@ describe('openingTimesParser', () => {
       const syndicationXml = getSampleResponse('syndication_responses/pharmacy_overview.xml');
       const openingTimes = openingTimesParser('reception', syndicationXml);
       expect(openingTimes).to.have.keys(weekdays);
-      expect(openingTimes.monday.times).to.eql([
-        { fromTime: '08:00', toTime: '13:00' },
-        { fromTime: '13:00', toTime: '19:30' },
+      expect(openingTimes.monday).to.eql([
+        { opens: '08:00', closes: '13:00' },
+        { opens: '13:00', closes: '19:30' },
       ]);
-      expect(openingTimes.friday.times).to.eql([
-        { fromTime: '08:00', toTime: '13:00' },
-        { fromTime: '13:00', toTime: '18:00' },
+      expect(openingTimes.friday).to.eql([
+        { opens: '08:00', closes: '13:00' },
+        { opens: '13:00', closes: '18:00' },
       ]);
-      expect(openingTimes.sunday.times).to.eql(['Closed']);
+      expect(openingTimes.sunday).to.eql([]);
     });
 
     it('should get single slot opening times from syndication response', () => {
@@ -29,26 +29,26 @@ describe('openingTimesParser', () => {
         getSampleResponse('syndication_responses/pharmacy_overview_single_time_slot.xml');
       const openingTimes = openingTimesParser('reception', syndicationXml);
       expect(openingTimes).to.have.keys(weekdays);
-      expect(openingTimes.monday.times).to.eql([
-        { fromTime: '08:00', toTime: '19:30' },
+      expect(openingTimes.monday).to.eql([
+        { opens: '08:00', closes: '19:30' },
       ]);
-      expect(openingTimes.friday.times).to.eql([
-        { fromTime: '08:00', toTime: '19:30' },
+      expect(openingTimes.friday).to.eql([
+        { opens: '08:00', closes: '19:30' },
       ]);
-      expect(openingTimes.sunday.times).to.eql(['Closed']);
+      expect(openingTimes.sunday).to.eql([]);
     });
 
     it('should get single type opening times from syndication response', () => {
       const syndicationXml = getSampleResponse('syndication_responses/pharmacy_opening_times.xml');
       const openingTimes = openingTimesParser('general', syndicationXml);
       expect(openingTimes).to.have.keys(weekdays);
-      expect(openingTimes.monday.times).to.eql([
-        { fromTime: '09:00', toTime: '17:30' },
+      expect(openingTimes.monday).to.eql([
+        { opens: '09:00', closes: '17:30' },
       ]);
-      expect(openingTimes.friday.times).to.eql([
-        { fromTime: '09:00', toTime: '17:30' },
+      expect(openingTimes.friday).to.eql([
+        { opens: '09:00', closes: '17:30' },
       ]);
-      expect(openingTimes.sunday.times).to.eql(['Closed']);
+      expect(openingTimes.sunday).to.eql([]);
     });
 
     it('should handle missing opening times', () => {


### PR DESCRIPTION
Using the latest branch from `moment-opening-times` e.g. git://github.com/nhsuk/moment-opening-times.git#feature/change-opening-times-format added the functionality to show open results on the results-file route.

I've made some changes to the openingTimes parser to ensure all existing functionality on the main results route continues to work.

The addition of checking the orgs for whether they are open or not has increased the duration of the filter operation. I'll look at reducing that next...