### PR TITLE
:metal: Search from point with greater choice

### DIFF
--- a/app/lib/getPharmacies.js
+++ b/app/lib/getPharmacies.js
@@ -54,13 +54,14 @@ function nearby(searchPoint, geo, limit) {
   for (let i = 0; i < sortedOrgs.length; i++) {
     const item = sortedOrgs[i];
     const openingTimes = item.openingTimes;
+    const now = moment();
     let isOpen;
     let openingTimesMessage;
 
     if (openingTimes) {
       const openingTimesMoment = new OpeningTimes(item.openingTimes.general, 'Europe/London');
-      openingTimesMessage = openingTimesMoment.getOpeningHoursMessage(moment());
-      isOpen = openingTimesMoment.isOpen(moment());
+      openingTimesMessage = openingTimesMoment.getOpeningHoursMessage(now);
+      isOpen = openingTimesMoment.isOpen(now);
       if (isOpen && openServiceCount < numberOfOpenToReturn) {
         openServiceCount++;
         openServices.push(item);

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "geolib": "^2.0.21",
     "memory-cache": "^0.1.6",
     "moment": "^2.14.1",
-    "moment-opening-times": "git://github.com/nhsuk/moment-opening-times.git#feature/change-opening-times-format",
+    "moment-opening-times": "git://github.com/nhsuk/moment-opening-times.git",
     "morgan": "^1.6.1",
     "ngeohash": "^0.6.0",
     "nunjucks": "^2.4.2",

--- a/test/unit/lib/getPharmacies.js
+++ b/test/unit/lib/getPharmacies.js
@@ -11,7 +11,7 @@ const expect = chai.expect;
 
 describe('Nearby', () => {
   let geo = [];
-  const searchPoint = { latitude: 50.08545303344, longitude: -1.576518416404 };
+  const searchPoint = { latitude: 53.797431921096, longitude: -1.55275457242333 };
 
   describe('happy path', () => {
     beforeEach('load data', () => {
@@ -60,7 +60,7 @@ describe('Nearby', () => {
     });
 
     it('should return the nearest obj first', () => {
-      const nearestIdentifier = 'FA040';
+      const nearestIdentifier = 'FFP17';
 
       const results = pharmacies.nearby(searchPoint, geo).nearbyServices;
 


### PR DESCRIPTION
3 orgs are returned in the middle of the night e.g. 2-4 am from this point. The other point was too far away from a good selection of orgs with wide ranging opening times.

And, I noticed 2 instances of moment were being used to check for the opening times. This could have caused it to have been open for the check in one instant and then shut in the other. Now the same value is used for both checks.

I've also included the change to use the latest version of the moment lib repo since the changes are all merged into master and are working.