### PR TITLE
:pushpin: Provide as much context in maps link as possible

### DIFF
--- a/app/lib/mapLink.js
+++ b/app/lib/mapLink.js
@@ -1,0 +1,31 @@
+require('object.values').shim();
+
+function joinAllTruthyValues(obj) {
+  return Object.values(obj)
+    .filter((value) => value)
+    .join();
+}
+
+function addUrl(location, inputList) {
+  const start = `saddr=${location}`;
+
+  return inputList.map((item) => {
+    const address = joinAllTruthyValues(item.address);
+    const fullNameAndAddress =
+      `${item.name},${address}`;
+    const destination = `daddr=${fullNameAndAddress}`;
+    const near = `near=${fullNameAndAddress}`;
+
+    const mapUrl =
+      `https://www.google.com/maps?${start}&${destination}&${near}`
+      .replace(/ /g, '+');
+
+    // eslint-disable-next-line no-param-reassign
+    item.mapUrl = mapUrl;
+    return item;
+  });
+}
+
+module.exports = {
+  addUrl,
+};

--- a/app/middleware/prerender.js
+++ b/app/middleware/prerender.js
@@ -1,7 +1,8 @@
+const mapLink = require('../lib/mapLink');
+
 function results(req, res, next) {
   const open = req.query.open || 'true';
   const location = res.locals.location;
-  const start = `saddr=${location}`;
   let altResultsUrl = '';
 
   if (open === 'true') {
@@ -10,19 +11,8 @@ function results(req, res, next) {
     altResultsUrl = `${res.locals.SITE_ROOT}/results?location=${location}&open=true`;
   }
 
-  const mappedOrgs = res.locals.nearbyServices.map((item) => {
-    // TODO: extract to lib
-    const fullAddress = `${item.name},${item.address.line1}`.replace(/ /g, '+');
-    const destination = `daddr=${fullAddress}`;
-    const near = `near=${fullAddress}`;
-
-    // eslint-disable-next-line no-param-reassign
-    item.googleMapsQuery = `${start}&${destination}&${near}`;
-    return item;
-  });
-
   /* eslint-disable no-param-reassign */
-  res.locals.nearbyServices = mappedOrgs;
+  res.locals.nearbyServices = mapLink.addUrl(location, res.locals.nearbyServices);
   res.locals.altResultsUrl = altResultsUrl;
   res.locals.open = open;
   /* eslint-enable no-param-reassign */

--- a/app/views/results.nunjucks
+++ b/app/views/results.nunjucks
@@ -49,7 +49,7 @@
   <div class="column__one-half column__one-half--tablecell column__one-half--alignbottom">
     <p>{{ service.distanceInMiles | round(1) }} miles away</p>
 
-    <a href="https://www.google.com/maps?{{service.googleMapsQuery}}" class="button cta cta-blue button--nomarginright">See on map and get directions</a>
+    <a href="{{service.mapUrl}}" class="button cta cta-blue button--nomarginright">See on map and get directions</a>
   </div>
 </div>
 <hr />

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "morgan": "^1.6.1",
     "ngeohash": "^0.6.0",
     "nunjucks": "^2.4.2",
+    "object.values": "^1.0.3",
     "postcode": "^0.2.5"
   },
   "devDependencies": {

--- a/test/unit/lib/mapLink.js
+++ b/test/unit/lib/mapLink.js
@@ -1,0 +1,80 @@
+require('object.values').shim();
+const mapLink = require('../../../app/lib/mapLink');
+const chai = require('chai');
+
+const expect = chai.expect;
+
+describe('mapLink', () => {
+  describe('addUrl', () => {
+    const location = 'some place';
+
+    it('should add an additional property to all items in the input list with the google maps Url',
+    () => {
+      const nameOne = 'place name one';
+      const nameTwo = 'place name two';
+      const address = {
+        line1: 'line1',
+        line2: 'line2',
+        line3: 'line3',
+        city: 'city',
+        county: 'county',
+        postcode: 'AB12 3CD',
+      };
+      const inputList = [{
+        name: nameOne,
+        address,
+      },
+        {
+          name: nameTwo,
+          address,
+        }];
+      const start = `saddr=${location}`;
+      const nameAndAddressOne = `${nameOne},${Object.values(address).join()}`;
+      const destinationOne = `daddr=${nameAndAddressOne}`;
+      const nearOne = `near=${nameAndAddressOne}`;
+
+      const nameAndAddressTwo = `${nameTwo},${Object.values(address).join()}`;
+      const destinationTwo = `daddr=${nameAndAddressTwo}`;
+      const nearTwo = `near=${nameAndAddressTwo}`;
+
+      const expectedMapLinkOne =
+        `https://www.google.com/maps?${start}&${destinationOne}&${nearOne}`.replace(/ /g, '+');
+
+      const expectedMapLinkTwo =
+        `https://www.google.com/maps?${start}&${destinationTwo}&${nearTwo}`.replace(/ /g, '+');
+
+      const results = mapLink.addUrl(location, inputList);
+
+      expect(results).to.not.be.equal(undefined);
+      expect(results).to.be.an('array');
+      expect(results.length).to.be.equal(2);
+      expect(results[0].mapUrl).to.be.equal(expectedMapLinkOne);
+      expect(results[1].mapUrl).to.be.equal(expectedMapLinkTwo);
+    });
+    it('should remove any empty, null or undefined address properties', () => {
+      const inputList = [{
+        name: 'name',
+        address: {
+          line1: 'line1',
+          line2: '',
+          line3: null,
+          city: '',
+          county: undefined,
+          postcode: 'AB12 3CD',
+        },
+      }];
+
+      const destination = 'name,line1,AB12+3CD';
+      const expectedMapLinkOne =
+        `https://www.google.com/maps?saddr=${location}&daddr=${destination}&near=${destination}`
+        .replace(/ /g, '+');
+
+      const results = mapLink.addUrl(location, inputList);
+
+      expect(results).to.not.be.equal(undefined);
+      expect(results).to.be.an('array');
+      expect(results.length).to.be.equal(1);
+      expect(results[0].mapUrl).to.be.equal(expectedMapLinkOne);
+    });
+  });
+});


### PR DESCRIPTION
No error handling added atm, which is as it was previously. It will still blow up should there not be any address on the item. However, what to do in this scenario needs a bit of thinking about so whilst that is going on this should add some value without degrading what was previously there.

I've added a package for providing the functionality for `Object.values(obj)` which is pretty handy for getting the values of the `obj`. This is functionality that is added in node 8+ but not available in 6 

Fixes #116