### PR TITLE
:closed_lock_with_key: Set Azure to redirect all traffic to https

### DIFF
--- a/web.config
+++ b/web.config
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     This configuration file is required if iisnode is used to run node processes behind
+     IIS or IIS Express.  For more information, visit:
+
+     https://github.com/tjanczuk/iisnode/blob/master/src/samples/configuration/web.config
+-->
+
+<configuration>
+  <system.webServer>
+    <!-- Visit http://blogs.msdn.com/b/windowsazure/archive/2013/11/14/introduction-to-websockets-on-windows-azure-web-sites.aspx for more information on WebSocket support -->
+    <webSocket enabled="false" />
+    <handlers>
+      <!-- Indicates that the server.js file is a node.js site to be handled by the iisnode module -->
+      <add name="iisnode" path="app.js" verb="*" modules="iisnode"/>
+    </handlers>
+    <rewrite>
+      <rules>
+        <!-- Do not interfere with requests for node-inspector debugging -->
+        <rule name="NodeInspector" patternSyntax="ECMAScript" stopProcessing="true">
+          <match url="^app.js\/debug[\/]?" />
+        </rule>
+
+        <!-- First we consider whether the incoming URL matches a physical file in the /public folder -->
+        <rule name="StaticContent">
+          <action type="Rewrite" url="public{REQUEST_URI}"/>
+        </rule>
+
+        <!-- All other URLs are mapped to the node.js site entry point -->
+        <rule name="DynamicContent">
+          <conditions>
+            <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="True"/>
+          </conditions>
+          <action type="Rewrite" url="app.js"/>
+        </rule>
+      </rules>
+    </rewrite>
+
+    <!-- 'bin' directory has no special meaning in node.js and apps can be placed in it -->
+    <security>
+      <requestFiltering>
+        <hiddenSegments>
+          <remove segment="bin"/>
+        </hiddenSegments>
+      </requestFiltering>
+    </security>
+
+    <!-- Make sure error responses are left untouched -->
+    <httpErrors existingResponse="PassThrough" />
+
+    <!--
+      You can control how Node is hosted within IIS using the following options:
+        * watchedFiles: semi-colon separated list of files that will be watched for changes to restart the server
+        * node_env: will be propagated to node as NODE_ENV environment variable
+        * debuggingEnabled - controls whether the built-in debugger is enabled
+
+      See https://github.com/tjanczuk/iisnode/blob/master/src/samples/configuration/web.config for a full list of options
+    -->
+    <!--<iisnode watchedFiles="web.config;*.js"/>-->
+  </system.webServer>
+</configuration>

--- a/web.config
+++ b/web.config
@@ -11,7 +11,7 @@
     <!-- Visit http://blogs.msdn.com/b/windowsazure/archive/2013/11/14/introduction-to-websockets-on-windows-azure-web-sites.aspx for more information on WebSocket support -->
     <webSocket enabled="false" />
     <handlers>
-      <!-- Indicates that the server.js file is a node.js site to be handled by the iisnode module -->
+      <!-- Indicates that the app.js file is a node.js site to be handled by the iisnode module -->
       <add name="iisnode" path="app.js" verb="*" modules="iisnode"/>
     </handlers>
     <rewrite>
@@ -57,15 +57,5 @@
 
     <!-- Make sure error responses are left untouched -->
     <httpErrors existingResponse="PassThrough" />
-
-    <!--
-      You can control how Node is hosted within IIS using the following options:
-        * watchedFiles: semi-colon separated list of files that will be watched for changes to restart the server
-        * node_env: will be propagated to node as NODE_ENV environment variable
-        * debuggingEnabled - controls whether the built-in debugger is enabled
-
-      See https://github.com/tjanczuk/iisnode/blob/master/src/samples/configuration/web.config for a full list of options
-    -->
-    <!--<iisnode watchedFiles="web.config;*.js"/>-->
   </system.webServer>
 </configuration>

--- a/web.config
+++ b/web.config
@@ -16,6 +16,16 @@
     </handlers>
     <rewrite>
       <rules>
+        <!-- BEGIN rule TAG FOR HTTPS REDIRECT -->
+        <rule name="Force HTTPS" enabled="true">
+          <match url="(.*)" ignoreCase="false" />
+          <conditions>
+            <add input="{HTTPS}" pattern="off" />
+          </conditions>
+          <action type="Redirect" url="https://{HTTP_HOST}/{R:1}" appendQueryString="true" redirectType="Permanent" />
+        </rule>
+        <!-- END rule TAG FOR HTTPS REDIRECT -->
+
         <!-- Do not interfere with requests for node-inspector debugging -->
         <rule name="NodeInspector" patternSyntax="ECMAScript" stopProcessing="true">
           <match url="^app.js\/debug[\/]?" />


### PR DESCRIPTION
Setting up environment in Azure to test the change before merging where it will be automatically deployed to the staging slot.

New slot added and pointing to this branch i.e. `feature/https-all-traffic`
http://connecting-to-services-steve-test.azurewebsites.net/

The site automatically redirects to https://connecting-to-services-steve-test.azurewebsites.net/finders/find-help

Fixes #146