### PR TITLE
:relieved: Clone open obj once opening info has been added

### DIFF
--- a/app/lib/getPharmacies.js
+++ b/app/lib/getPharmacies.js
@@ -61,21 +61,23 @@ function nearby(searchPoint, geo, limit) {
 
     if (openingTimes) {
       const openingTimesMoment = new OpeningTimes(item.openingTimes.general, 'Europe/London');
+
       openingTimesMessage = openingTimesMoment.getOpeningHoursMessage(now);
       isOpen = openingTimesMoment.isOpen(now);
-      if (isOpen && openServiceCount < numberOfOpenToReturn) {
-        openServiceCount++;
-        openServices.push(utils.deepClone(item));
-      }
     } else {
       openingTimesMessage = 'Call for opening times';
       isOpen = false;
     }
-    serviceCount++;
-    /* eslint-disable no-param-reassign */
+
     item.openingTimesMessage = openingTimesMessage;
     item.isOpen = isOpen;
-    /* eslint-enable no-param-reassign */
+
+    if (isOpen && openServiceCount < numberOfOpenToReturn) {
+      openServiceCount++;
+      openServices.push(utils.deepClone(item));
+    }
+
+    serviceCount++;
 
     if (openServiceCount >= numberOfOpenToReturn && serviceCount >= maxResults) {
       break;

--- a/test/unit/lib/getPharmacies.js
+++ b/test/unit/lib/getPharmacies.js
@@ -74,7 +74,24 @@ describe('Nearby', () => {
     });
 
     it('should return the opening times message and open state', () => {
-      const results = pharmacies.nearby(searchPoint, geo).openServices;
+      const alwaysOpenOrg = {
+        latitude: searchPoint.latitude,
+        longitude: searchPoint.longitude,
+        openingTimes: {
+          general: {
+            monday: [{ opens: '00:00', closes: '23:59' }],
+            tuesday: [{ opens: '00:00', closes: '23:59' }],
+            wednesday: [{ opens: '00:00', closes: '23:59' }],
+            thursday: [{ opens: '00:00', closes: '23:59' }],
+            friday: [{ opens: '00:00', closes: '23:59' }],
+            saturday: [{ opens: '00:00', closes: '23:59' }],
+            sunday: [{ opens: '00:00', closes: '23:59' }],
+          },
+        },
+      };
+      function nearbyStub() { return [alwaysOpenOrg]; }
+      const oneOpenOrgGeo = { nearBy: nearbyStub };
+      const results = pharmacies.nearby(searchPoint, oneOpenOrgGeo).openServices;
 
       expect(results[0].isOpen).to.be.equal(true);
       expect(results[0].openingTimesMessage).to.not.be.equal('Call for opening times');


### PR DESCRIPTION
This fixes a bug that was introduced when [open objects started to be cloned](https://github.com/nhsuk/connecting-to-services/commit/a0575433f36e783f476e32e168602825385f8980). The problem being that both `isOpen` and `openingTimesMessage` were not added to the object being cloned before it was cloned. This can be seen on the website by simply visiting the results page for the first time with a new postcode. No opening time message will be displayed. This changes fixes that so the message should be displayed immediately and consistently (as it has been in the past).