### PR TITLE
:blue_heart: Add meta tag for service type tracking on results

### DIFF
--- a/app/views/layout.nunjucks
+++ b/app/views/layout.nunjucks
@@ -41,6 +41,7 @@
       </script>
     {% endif %}
 
+    {% block meta %}{% endblock %}
   </head>
 
   <body>

--- a/app/views/results.nunjucks
+++ b/app/views/results.nunjucks
@@ -2,6 +2,10 @@
 
 {% block pageTitle %}All service results{% endblock %}
 
+{% block meta %}
+<meta name="DCSext.ServiceName" content="pharmacies" />
+{% endblock %}
+
 {% block header %}{{ headerMessage }}{% endblock %}
 
 {% block content %}


### PR DESCRIPTION
For webtrends - In order to know what type of services are displayed in the results a meta tag needs to be added to the page. When the service types are more than just pharmacies this will need to be dynamically generated rather than hard coded as it is now.

The information would most likely come from the `organisationType` property on the org data. When there are more than one service type in the results these should be semicolon (`;`) separated.