### PR TITLE
:rocket: Add simple performance test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 public/components
 coverage/
+reports/
 
 .sass-cache
 npm-debug.log
@@ -10,3 +11,6 @@ npm-debug.log.*
 .coveralls.yml
 
 *.swp
+
+# Use .keep files to keep empty folders
+!.keep

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "start-logging": "node app.js | ./node_modules/.bin/bunyan",
     "lint": "eslint --ext .js,.json . && cat .bithoundrc | eslint --stdin --stdin-filename=f.json",
     "test": "NODE_ENV=test mocha --recursive test",
+    "artillery": "artillery run ./test/perf/all-results.json -o ./reports/all-results.json",
+    "artillery-report": "artillery report ./reports/all-results.json",
     "watch-dev": "nodemon app.js | ./node_modules/.bin/bunyan",
     "watch-dev-debug": "NODE_ENV=development && npm run watch-dev",
     "watch-lint": "esw --watch .",
@@ -59,6 +61,7 @@
     "snyk": "^1.19.1"
   },
   "devDependencies": {
+    "artillery": "^1.5.0-17",
     "chai": "^3.5.0",
     "chai-http": "^3.0.0",
     "cheerio": "^0.22.0",

--- a/test/perf/all-results.json
+++ b/test/perf/all-results.json
@@ -1,0 +1,16 @@
+{
+  "config": {
+    "target": "http://localhost:3000",
+    "phases": [
+      { "duration": 5, "arrivalRate": 1 },
+      { "pause": 5 },
+      { "duration": 60, "arrivalRate": 1 }
+    ]
+  },
+  "scenarios": [
+    {
+      "name": "Get results for ls1",
+      "flow": [ { "get": { "url": "/finders/results?location=ls1" } } ]
+    }
+  ]
+}


### PR DESCRIPTION
This is a very simple test that will currently only work when run on a dev machine due to the value of `target` in the test script. Target can be overridden on the [command line](https://artillery.io/docs/cli_reference.html) so it could be changed based on the environment it need to run against. Or, different environments can be specified in the script and chosen at runtime. More information available at https://artillery.io/docs/index.html

Things to think about are how this would be work in practice as part of the CI pipeline. Atm Heroku review apps are used but they are deployed by Heroku. That information (the URL) is not available in Travis (but could be calculated). However, the deployments could be moved to become Travis's responsibility, but, I don't think review apps are able to be used taking that approach.

It might be the case that the tests are run against persistent environments and the deployment pipeline is changed e.g. use `pre-release` branch for all working feature merges and only once everything is working on that branch does it get merged into `master` (which is still used as the main site's deployment source).