### PR TITLE
:fire_engine: Remove X-Powered-By and Server headers

### DIFF
--- a/web.config
+++ b/web.config
@@ -48,12 +48,17 @@
 
     <!-- 'bin' directory has no special meaning in node.js and apps can be placed in it -->
     <security>
-      <requestFiltering>
+      <requestFiltering removeServerHeader ="true">
         <hiddenSegments>
           <remove segment="bin"/>
         </hiddenSegments>
       </requestFiltering>
     </security>
+    <httpProtocol>
+      <customHeaders>
+        <remove name="X-Powered-By"/>
+      </customHeaders>
+    </httpProtocol>
 
     <!-- Make sure error responses are left untouched -->
     <httpErrors existingResponse="PassThrough" />


### PR DESCRIPTION
The change here should mean that when the code is deployed by Azure the headers of `Server` and `X-Powered-By` are no longer returned to the client. This can only be tested on Azure.

I've setup https://connecting-to-services-steve-test.azurewebsites.net/finders/find-help to pull from this branch so it can be tested.

Note that neither of the 2 aforementioned headers are present on this site whereas they are on https://connecting-to-services-staging.azurewebsites.net/finders/find-help

This change doesn't alter the scan grade from [https://securityheaders.io](https://securityheaders.io/?q=https%3A%2F%2Fconnecting-to-services-steve-test.azurewebsites.net%2Ffinders%2Ffind-help&hide=on&followRedirects=on) but removing as much info from possible is good practice.

As can be seen here:

Excessive headers on staging: https://asafaweb.com/Scan?Url=https%3A%2F%2Fconnecting-to-services-staging.azurewebsites.net%2Ffinders%2Ffind-help

and not on the site running this change: https://asafaweb.com/Scan?Url=https%3A%2F%2Fconnecting-to-services-steve-test.azurewebsites.net%2Ffinders%2Ffind-help