### PR TITLE
:ferris_wheel: Mute dep that has been patched by synk

### DIFF
--- a/.bithoundrc
+++ b/.bithoundrc
@@ -53,6 +53,9 @@
   "dependencies": {
     "unused-ignores": [
       "snyk"
+    ],
+    "mute": [
+    "splunk-bunyan-logger"
     ]
   }
 }


### PR DESCRIPTION
In `splunk-bunyan-logger` there is a vulnerable dependency. This has been patched by Synk but bitHound doesn't know that.
This change mutes that dependency warning (as it has been dealt with).