### PR TITLE
:hotsprings: Allow hotjar.com access over any port

### DIFF
--- a/config/express.js
+++ b/config/express.js
@@ -58,7 +58,7 @@ module.exports = (app, config) => {
       ],
       connectSrc: [
         '\'self\'',
-        'https://*.hotjar.com',
+        'https://*.hotjar.com:*',
         'wss://*.hotjar.com',
       ],
     },

--- a/test/integration/app.js
+++ b/test/integration/app.js
@@ -42,7 +42,7 @@ describe('page response', () => {
     chai.request(server)
     .get(`${constants.SITE_ROOT}/finders/find-help`)
     .end((err, res) => {
-      expect(res).to.have.header('Content-Security-Policy', 'default-src \'self\'; script-src \'self\' \'unsafe-inline\' data: www.google-analytics.com s.webtrends.com statse.webtrendslive.com static.hotjar.com script.hotjar.com cdn.jsdelivr.net; img-src \'self\' data: www.google-analytics.com statse.webtrendslive.com hm.webtrends.com; style-src \'self\' \'unsafe-inline\' fast.fonts.net https://dhrlmnmyf2njb.cloudfront.net/; font-src fast.fonts.net https://dhrlmnmyf2njb.cloudfront.net/; connect-src \'self\' https://*.hotjar.com wss://*.hotjar.com');
+      expect(res).to.have.header('Content-Security-Policy', 'default-src \'self\'; script-src \'self\' \'unsafe-inline\' data: www.google-analytics.com s.webtrends.com statse.webtrendslive.com static.hotjar.com script.hotjar.com cdn.jsdelivr.net; img-src \'self\' data: www.google-analytics.com statse.webtrendslive.com hm.webtrends.com; style-src \'self\' \'unsafe-inline\' fast.fonts.net https://dhrlmnmyf2njb.cloudfront.net/; font-src fast.fonts.net https://dhrlmnmyf2njb.cloudfront.net/; connect-src \'self\' https://*.hotjar.com:* wss://*.hotjar.com');
       expect(res).to.have.header('X-Xss-Protection', '1; mode=block');
       expect(res).to.have.header('X-Frame-Options', 'DENY');
       expect(res).to.have.header('X-Content-Type-Options', 'nosniff');


### PR DESCRIPTION
Changes based on:
`Content-Security-Policy: default-src https://scotthelme.co.uk:*` would only allow assets to be loaded from my domain over https on any port.

Sourced from https://scotthelme.co.uk/content-security-policy-an-introduction/