### PR TITLE
:confounded: Make review apps use splunk logging

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,6 +2,14 @@
   "name": "connecting to services",
   "scripts": {
   },
+  "env": {
+    "SPLUNK_HEC_ENDPOINT": {
+      "required": true
+    },
+    "SPLUNK_HEC_TOKEN": {
+      "required": true
+    }
+  },
   "formation": {
     "web": {
       "quantity": 1


### PR DESCRIPTION
To test this works the review apps should work right off the bat and any logs should be getting pumped straight into Splunk