### PR TITLE
Feature/log locations

### DIFF
--- a/app/lib/postcodes.js
+++ b/app/lib/postcodes.js
@@ -38,11 +38,11 @@ function lookup(res, next) {
           next();
           break;
         case 404:
-          log.warn({ res: postcodeRes }, '404 from postcodes.io');
+          log.warn({ res: postcodeRes, location }, '404 from postcodes.io');
           next({ type: 'invalid-postcode', message: messages.invalidPostcodeMessage(location) });
           break;
         default:
-          log.warn({ url, response: postcodeRes.statusCode });
+          log.warn({ url, response: postcodeRes.statusCode, location });
           next(
             {
               type: 'postcode-service-error',
@@ -53,7 +53,7 @@ function lookup(res, next) {
     });
   }).on('error', (e) => {
     // TODO: Add 'standard' error
-    log.error({ err: e }, 'Postcode lookup failed');
+    log.error({ err: e, location }, 'Postcode lookup failed');
     next({ type: 'postcode-service-error', message: e.message });
   });
 }

--- a/app/middleware/locationValidator.js
+++ b/app/middleware/locationValidator.js
@@ -13,6 +13,7 @@ function validateLocation(req, res, next) {
   res.locals.location = validationResult.input;
 
   if (validationResult.errorMessage) {
+    log.info({ location }, 'Location failed validation');
     // eslint-disable-next-line no-param-reassign
     res.locals.errorMessage = validationResult.errorMessage;
     renderer.findHelp(req, res);


### PR DESCRIPTION
In order to help identify if there are particular locations (postcodes) that are not found via postcodes.io or failure validation those failing need to be recorded. This change logs failed location entries either. They have either failed postcode regex validation or returned an error response from the lookup.
Logging this information will also create a record of other i.e. non-postcode data entries that could help in prioritising new future features.