### PR TITLE
:tea: Remove hard coded back link

### DIFF
--- a/app/middleware/setLocals.js
+++ b/app/middleware/setLocals.js
@@ -1,8 +1,10 @@
 function fromRequest(req, res, next) {
-  // eslint-disable-next-line no-param-reassign
+  /* eslint-disable no-param-reassign */
   res.locals.location = req.query.location;
-  // eslint-disable-next-line no-param-reassign
   res.locals.context = req.query.context || '';
+  // eslint-disable-next-line no-script-url
+  res.locals.backLink = req.get('referer') || 'javascript:history.back();';
+  /* eslint-enable no-param-reassign */
   next();
 }
 

--- a/app/views/find-help.nunjucks
+++ b/app/views/find-help.nunjucks
@@ -51,7 +51,7 @@ Find a pharmacy
             <input type="submit" class="button" value="Continue">
           </div>
         </div>
-        <p class="u-margintop5"><a href="{{ SITE_ROOT }}/stomach-ache" class="link-back">Back</a></p>
+        <p class="u-margintop5"><a href="{{ backLink }}" class="link-back">Back</a></p>
       </div>
     </div>
 </form>


### PR DESCRIPTION
Use the `referer` header value if present otherwise fall back to JS version. The reason for the fallback is due to the header not guaranteed to be sent.