### PR TITLE
:do_not_litter: Use logger that doesn't throw exceptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "moment": "^2.14.1",
     "moment-opening-times": "git://github.com/nhsuk/moment-opening-times.git#2.0.0",
     "ngeohash": "^0.6.0",
-    "nhsuk-bunyan-logger": "git://github.com/nhsuk/bunyan-logger.git#1.0.3",
+    "nhsuk-bunyan-logger": "nhsuk/bunyan-logger#1.0.4",
     "nunjucks": "^2.4.2",
     "object.values": "^1.0.3",
     "postcode": "^0.2.5",


### PR DESCRIPTION
Fixes an issue where network connectivity loss to the
Splunk Http Event Collector would throw an exception
that bubbled up to the consumer of the library and
caused that consumer to crash. Rather than handle the
exception in the consumer the library takes care of it.


In order to test the change has been successful the most robust way I've found is to run the site locally with the network turned off. If the logger changes are good the site will continue to function when it tries to load the `/finders/find-help` page. The site will 'have technical' problems if a search is done due to postcodes.io not being able to be reached. This is as expected.

The Splunk stream is used only in a production environment. In order to run the app so it will attempt to log to Splunk, the command to run is:
`NODE_ENV=production SPLUNK_HEC_TOKEN={SPLUNK_HEC_TOKEN} SPLUNK_HEC_ENDPOINT={SPLUNK_HEC_ENDPOINT} npm run watch-dev`
where the variables, denoted by `{...}` are replaced with bonafide values.