### PR TITLE
:bug: Whitelist hotjar to get survey to work

### DIFF
--- a/config/express.js
+++ b/config/express.js
@@ -28,6 +28,9 @@ module.exports = (app, config) => {
       defaultSrc: [
         '\'self\'',
       ],
+      childSrc: [
+        'https://*.hotjar.com:*',
+      ],
       scriptSrc: [
         '\'self\'',
         '\'unsafe-inline\'',

--- a/test/integration/app.js
+++ b/test/integration/app.js
@@ -43,7 +43,7 @@ describe('page response', () => {
     chai.request(server)
     .get(`${constants.SITE_ROOT}/finders/find-help`)
     .end((err, res) => {
-      expect(res).to.have.header('Content-Security-Policy', 'default-src \'self\'; script-src \'self\' \'unsafe-inline\' \'unsafe-eval\' data: www.google-analytics.com s.webtrends.com statse.webtrendslive.com static.hotjar.com script.hotjar.com cdn.jsdelivr.net; img-src \'self\' data: static.hotjar.com www.google-analytics.com statse.webtrendslive.com hm.webtrends.com; style-src \'self\' \'unsafe-inline\' fast.fonts.net https://dhrlmnmyf2njb.cloudfront.net/; font-src fast.fonts.net https://dhrlmnmyf2njb.cloudfront.net/; connect-src \'self\' https://*.hotjar.com:* wss://*.hotjar.com');
+      expect(res).to.have.header('Content-Security-Policy', 'default-src \'self\'; child-src https://*.hotjar.com:*; script-src \'self\' \'unsafe-inline\' \'unsafe-eval\' data: www.google-analytics.com s.webtrends.com statse.webtrendslive.com static.hotjar.com script.hotjar.com cdn.jsdelivr.net; img-src \'self\' data: static.hotjar.com www.google-analytics.com statse.webtrendslive.com hm.webtrends.com; style-src \'self\' \'unsafe-inline\' fast.fonts.net https://dhrlmnmyf2njb.cloudfront.net/; font-src fast.fonts.net https://dhrlmnmyf2njb.cloudfront.net/; connect-src \'self\' https://*.hotjar.com:* wss://*.hotjar.com');
       expect(res).to.have.header('X-Xss-Protection', '1; mode=block');
       expect(res).to.have.header('X-Frame-Options', 'DENY');
       expect(res).to.have.header('X-Content-Type-Options', 'nosniff');


### PR DESCRIPTION
Using `child-src` rather than `frame-src` due to `frame-src` having been [deprecated](https://www.w3.org/TR/CSP2/#directive-frame-src)

To confirm this is working (at least before it is deployed to a site where the survey will be active) navigate to the results page of the deployment and check there are no warnings in the browser's console about `Refused to frame 'https://vars.hotjar.com/rcj-hotjar-265857.js?sv=5:44` (or similar). To see what errors are occurring - check them out on the live or staging site.