### PR TITLE
:package: Run tests in container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,9 @@ sudo: required
 services:
   - docker
 
-language: node_js
-
-node_js:
-- node
 script:
-- npm run lint
-- npm run generate-coverage
-- npm run check-coverage
-- npm run upload-coverage-coveralls
-- npm run upload-coverage-codacy
+  - docker build --build-arg NODE_ENV=development -t nhsuk/c2s .
+  - docker run -e TRAVIS=true -e TRAVIS_JOB_ID=$TRAVIS_JOB_ID -e TRAVIS_BRANCH=$TRAVIS_BRANCH -e COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN nhsuk/c2s sh -c "cd /code && npm run git-hook && npm run upload-coverage-coveralls && npm run upload-coverage-codacy"
 
 after_success:
 - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
 
 script:
   - docker build --build-arg NODE_ENV=development -t nhsuk/c2s .
-  - docker run -e TRAVIS=true -e TRAVIS_JOB_ID=$TRAVIS_JOB_ID -e TRAVIS_BRANCH=$TRAVIS_BRANCH -e COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN nhsuk/c2s sh -c "cd /code && npm run git-hook && npm run upload-coverage-coveralls && npm run upload-coverage-codacy"
+  - docker run -e TRAVIS=true -e TRAVIS_JOB_ID=$TRAVIS_JOB_ID -e TRAVIS_BRANCH=$TRAVIS_BRANCH -e COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN -e CODACY_PROJECT_TOKEN=$CODACY_PROJECT_TOKEN -e TRAVIS_COMMIT=$TRAVIS_COMMIT nhsuk/c2s sh -c "cd /code && npm run git-hook && npm run upload-coverage-coveralls && npm run upload-coverage-codacy"
 
 after_success:
 - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"


### PR DESCRIPTION
Instead of running tests on the CI's host OS we should be running them inside of the container. Using the `git-hook` script, linting is done, tests are run, code coverage generated and uploaded to both coveralls and codacy.