### PR TITLE
:bug: Build Docker image and env on success only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
 - npm run upload-coverage-coveralls
 - npm run upload-coverage-codacy
 
-after_script:
+after_success:
 - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
 - ./scripts/docker_ci.sh
 - ./scripts/rancher_pr_deploy.sh


### PR DESCRIPTION
I don't think there is a reason why the image should be created if the build has failed so I've changed the life cycle event to only do it when previous steps have been successful.

Source: https://docs.travis-ci.com/user/customizing-the-build/#The-Build-Lifecycle

Fixes #246