### PR TITLE
:no_entry: No longer need pyaml for deployments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ script:
   - docker-compose -f docker-compose-tests.yml run travis-tests
 
 after_success:
-  - pip install pyyaml
   - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
   - ./scripts/ci-deployment/docker_ci.sh
   - ./scripts/ci-deployment/rancher_pr_deploy.sh


### PR DESCRIPTION
This PR needs to be merged before #284 Note, it merges into branch `feature/yarnify` as opposed to `master`