### PR TITLE
:raising_hand: Be less specific about third party domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.15.0 / TBD
+===================
+- Be less specific about third party domains within content security policy
+
 0.14.1 / TBA
 ===================
 - Performance tests use threshold of 500ms

--- a/config/express.js
+++ b/config/express.js
@@ -48,7 +48,6 @@ module.exports = (app, config) => {
           '*.hotjar.com',
           '*.webtrends.com',
           '*.webtrendslive.com',
-          'cdn.jsdelivr.net',
         ],
         imgSrc: [
           '\'self\'',

--- a/config/express.js
+++ b/config/express.js
@@ -28,55 +28,51 @@ module.exports = (app, config) => {
     });
   log.info({ config: { nunjucksEnvironment } }, 'nunjucks environment configuration');
 
-  app.use(helmet.contentSecurityPolicy({
-    directives: {
-      defaultSrc: [
-        '\'self\'',
-      ],
-      childSrc: [
-        'https://*.hotjar.com:*',
-      ],
-      scriptSrc: [
-        '\'self\'',
-        '\'unsafe-inline\'',
-        '\'unsafe-eval\'',
-        'data:',
-        'www.google-analytics.com',
-        's.webtrends.com',
-        'statse.webtrendslive.com',
-        'static.hotjar.com',
-        'script.hotjar.com',
-        'cdn.jsdelivr.net',
-      ],
-      imgSrc: [
-        '\'self\'',
-        'data:',
-        'static.hotjar.com',
-        'www.google-analytics.com',
-        'statse.webtrendslive.com',
-        'hm.webtrends.com',
-      ],
-      styleSrc: [
-        '\'self\'',
-        '\'unsafe-inline\'',
-        'assets.nhs.uk',
-      ],
-      fontSrc: [
-        'assets.nhs.uk',
-      ],
-      connectSrc: [
-        '\'self\'',
-        'https://*.hotjar.com:*',
-        'wss://*.hotjar.com',
-      ],
-    },
+  app.use(helmet({
+    frameguard: { action: 'deny' },
+    hsts: { includeSubDomains: false },
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: [
+          '\'self\'',
+        ],
+        childSrc: [
+          '*.hotjar.com',
+        ],
+        scriptSrc: [
+          '\'self\'',
+          '\'unsafe-eval\'',
+          '\'unsafe-inline\'',
+          'data:',
+          '*.google-analytics.com',
+          '*.hotjar.com',
+          '*.webtrends.com',
+          '*.webtrendslive.com',
+          'cdn.jsdelivr.net',
+        ],
+        imgSrc: [
+          '\'self\'',
+          'data:',
+          '*.google-analytics.com',
+          '*.hotjar.com',
+          '*.webtrends.com',
+          '*.webtrendslive.com',
+        ],
+        styleSrc: [
+          '\'self\'',
+          '\'unsafe-inline\'',
+          'assets.nhs.uk',
+        ],
+        fontSrc: [
+          'assets.nhs.uk',
+        ],
+        connectSrc: [
+          '\'self\'',
+          '*.hotjar.com:*',
+        ],
+      },
+    }
   }));
-  app.use(helmet.xssFilter());
-  app.use(helmet.frameguard({ action: 'deny' }));
-  app.use(helmet.hidePoweredBy());
-  app.use(helmet.ieNoOpen());
-  app.use(helmet.noSniff());
-  app.use(helmet.hsts({ includeSubDomains: false }));
 
   app.use(locals(config));
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connecting-to-services",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "private": true,
   "description": "Helping to connect people to appropriate services, meeting their time, location and accessibility needs.",
   "scripts": {

--- a/test/integration/securityHeaders.js
+++ b/test/integration/securityHeaders.js
@@ -12,7 +12,7 @@ describe('app', () => {
     chai.request(server)
       .get(`${constants.SITE_ROOT}/finders/find-help`)
       .end((err, res) => {
-        expect(res).to.have.header('Content-Security-Policy', 'default-src \'self\'; child-src *.hotjar.com; script-src \'self\' \'unsafe-eval\' \'unsafe-inline\' data: *.google-analytics.com *.hotjar.com *.webtrends.com *.webtrendslive.com cdn.jsdelivr.net; img-src \'self\' data: *.google-analytics.com *.hotjar.com *.webtrends.com *.webtrendslive.com; style-src \'self\' \'unsafe-inline\' assets.nhs.uk; font-src assets.nhs.uk; connect-src \'self\' *.hotjar.com:*');
+        expect(res).to.have.header('Content-Security-Policy', 'default-src \'self\'; child-src *.hotjar.com; script-src \'self\' \'unsafe-eval\' \'unsafe-inline\' data: *.google-analytics.com *.hotjar.com *.webtrends.com *.webtrendslive.com; img-src \'self\' data: *.google-analytics.com *.hotjar.com *.webtrends.com *.webtrendslive.com; style-src \'self\' \'unsafe-inline\' assets.nhs.uk; font-src assets.nhs.uk; connect-src \'self\' *.hotjar.com:*');
         expect(res).to.have.header('X-Xss-Protection', '1; mode=block');
         expect(res).to.have.header('X-Frame-Options', 'DENY');
         expect(res).to.have.header('X-Content-Type-Options', 'nosniff');

--- a/test/integration/securityHeaders.js
+++ b/test/integration/securityHeaders.js
@@ -12,7 +12,7 @@ describe('app', () => {
     chai.request(server)
       .get(`${constants.SITE_ROOT}/finders/find-help`)
       .end((err, res) => {
-        expect(res).to.have.header('Content-Security-Policy', 'default-src \'self\'; child-src https://*.hotjar.com:*; script-src \'self\' \'unsafe-inline\' \'unsafe-eval\' data: www.google-analytics.com s.webtrends.com statse.webtrendslive.com static.hotjar.com script.hotjar.com cdn.jsdelivr.net; img-src \'self\' data: static.hotjar.com www.google-analytics.com statse.webtrendslive.com hm.webtrends.com; style-src \'self\' \'unsafe-inline\' assets.nhs.uk; font-src assets.nhs.uk; connect-src \'self\' https://*.hotjar.com:* wss://*.hotjar.com');
+        expect(res).to.have.header('Content-Security-Policy', 'default-src \'self\'; child-src *.hotjar.com; script-src \'self\' \'unsafe-eval\' \'unsafe-inline\' data: *.google-analytics.com *.hotjar.com *.webtrends.com *.webtrendslive.com cdn.jsdelivr.net; img-src \'self\' data: *.google-analytics.com *.hotjar.com *.webtrends.com *.webtrendslive.com; style-src \'self\' \'unsafe-inline\' assets.nhs.uk; font-src assets.nhs.uk; connect-src \'self\' *.hotjar.com:*');
         expect(res).to.have.header('X-Xss-Protection', '1; mode=block');
         expect(res).to.have.header('X-Frame-Options', 'DENY');
         expect(res).to.have.header('X-Content-Type-Options', 'nosniff');


### PR DESCRIPTION
Reason for being less specific on the domains is due to occassional
changes by the third parties which causes functionality to stop working
on our site.

Removal of scheme specification as it defaults to how the page has been
accessed.