### PR TITLE
ignore metrics test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.15.1 / TBA
+===================
+- Ignore metrics test when running githook as it only works in the container.
+
 0.15.0 / 2017-10-17
 ===================
 - Be less specific about third party domains within content security policy

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connecting-to-services",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "private": true,
   "description": "Helping to connect people to appropriate services, meeting their time, location and accessibility needs.",
   "scripts": {
@@ -8,8 +8,10 @@
     "coverage-check": "istanbul check-coverage --config .istanbul.yml",
     "coverage-generate": "yarn istanbul -- cover _mocha -- --exit --recursive",
     "coverage-generate-full": "yarn istanbul -- cover --include-all-sources _mocha -- --exit --recursive",
+    "coverage-generate-no-metrics": "yarn istanbul -- cover _mocha -- --exit mocha \"./test/**/!(metrics).js\"",
     "coverage-upload-coveralls": "cat ./coverage/lcov.info | coveralls",
-    "git-hook": "yarn lint && yarn coverage-generate && yarn coverage-check",
+    "git-hook": "yarn lint && yarn coverage-generate-no-metrics && yarn coverage-check",
+    "ci-hook": "yarn lint && yarn coverage-generate && yarn coverage-check",
     "istanbul": "NODE_ENV=test istanbul",
     "lint": "eslint --ext .js,.json .",
     "lint-watch": "esw --watch .",
@@ -19,7 +21,7 @@
     "start": "node app.js",
     "start-watch": "nodemon app.js | ./node_modules/bunyan/bin/bunyan & nodemon -e scss -x yarn build-css -- compact",
     "test": "NODE_ENV=test mocha --exit --recursive test",
-    "test-ci": "yarn git-hook && yarn coverage-upload-coveralls",
+    "test-ci": "yarn ci-hook && yarn coverage-upload-coveralls",
     "test-watch": "yarn test -- --watch --reporter min"
   },
   "repository": {


### PR DESCRIPTION
<!--
Thanks for wanting to contribute to this repository.

In order for the changes to be integrated into the repo with as little friction
as possible please follow the guidance here. This includes completing all
sections as fully as possible.
Prior to creating a Pull Request, please ensure there is an open issue for the
changes you wish to make. This will provide visibility to others early in the
process. Potentially other people will wish to help out. It also allows us to
validate the change is inline with our vision for the product.

Provide a general summary of your changes in the Title
-->

## Description
<!--- Describe your changes in detail -->
The metrics test is no longer run on the git-hook, only during the CI test.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

The metrics test needs the site running to return the expected results and only works in the container, not in the git-hook when running locally. The git hook would always fail when running locally.

The test has been disabled locally, but continues to run in the CI tests.

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->
- [x] Changes log in `CHANGELOG`
