### PR TITLE
:closed_lock_with_key: Add basic authentication to test environments in Rancher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-0.15.1 / TBA
+0.16.0 / 2017-10-31
 ===================
+- Add basic authentication to service when running test environments in Rancher
 - Ignore metrics test when running githook as it only works in the container.
 
 0.15.0 / 2017-10-17

--- a/README.md
+++ b/README.md
@@ -25,8 +25,14 @@ Use the `test` script for continuous testing during development.
 ## Test environments
 
 As the application is being developed, every Pull Request has its own test
-environment automatically built and deployed to. The path to the environment
-is added as a comment to the PR in GitHub.
+environment automatically built and deployed to.
+
+Every environment apart from the one we want the public to access requires
+basic authentication to access. The username and password are not secret, in
+fact they are included within environment variable table below.
+The intention with the authentication challenge is to prevent people whom may
+stumble across the site and not realise it is for testing, it also prevents
+access by search engines and other bots.
 
 ## Environment variables
 
@@ -45,15 +51,16 @@ application will fail to start and an appropriate message will be displayed.
 Environment variables are used to set application level settings for each
 environment.
 
-| Variable                         | Description                                                         | Default                 | Required |
-|:---------------------------------|:--------------------------------------------------------------------|:------------------------|----------|
-| `API_BASE_URL`                   | The fully qualified domain the api exists on e.g. `http://web.site` |                         | Yes      |
-| `NODE_ENV`                       | Node environment                                                    | development             |          |
-| `LOG_LEVEL`                      | Numeric [log level](https://github.com/trentm/node-bunyan#levels)   | Depends on `NODE_ENV`   |          |
-| `PORT`                           | Server port                                                         | 3000                    |          |
-| `GOOGLE_ANALYTICS_TRACKING_ID`   | [Google Analytics](https://www.google.co.uk/analytics) property id  |                         |          |
-| `WEBTRENDS_ANALYTICS_TRACKING_ID`| [Webtrends](https://www.webtrends.com/) tracking id                 |                         |          |
-| `HOTJAR_ANALYTICS_TRACKING_ID`   | [Hotjar](https://www.hotjar.com/) tracking id                       |                         |          |
+| Variable                           | Description                                                                                   | Default                   | Required   |
+| :--------------------------------- | :-------------------------------------------------------------------------------------------- | :------------------------ | ---------- |
+| `API_BASE_URL`                     | The fully qualified domain the api exists on e.g. `http://web.site`                           |                           | Yes        |
+| `NODE_ENV`                         | Node environment                                                                              | development               |            |
+| `LOG_LEVEL`                        | Numeric [log level](https://github.com/trentm/node-bunyan#levels)                             | Depends on `NODE_ENV`     |            |
+| `PORT`                             | Server port                                                                                   | 3000                      |            |
+| `GOOGLE_ANALYTICS_TRACKING_ID`     | [Google Analytics](https://www.google.co.uk/analytics) property id                            |                           |            |
+| `WEBTRENDS_ANALYTICS_TRACKING_ID`  | [Webtrends](https://www.webtrends.com/) tracking id                                           |                           |            |
+| `HOTJAR_ANALYTICS_TRACKING_ID`     | [Hotjar](https://www.hotjar.com/) tracking id                                                 |                           |            |
+| `BASIC_AUTH`                       | An MD5 encrypted [htpasswd](https://httpd.apache.org/docs/2.4/misc/password_encryptions.html) | test:test                 |            |
 
 ## FAQ
 

--- a/doc/adr/0008-add-basic-authentication-to-test-environments.md
+++ b/doc/adr/0008-add-basic-authentication-to-test-environments.md
@@ -1,0 +1,30 @@
+# 8. Add basic authentication to test environments
+
+Date: 2017-10-26
+
+## Status
+
+Accepted
+
+## Context
+
+Every environment the application is available in, be that development, review,
+staging or public are openly available to anybody. There is no access control
+at all.  This isn't suitable for a site that could be misinterpreted as the
+'real' version either by people or by search engines and other bots. There
+needs to be some form of hurdle to overcome in order to prompt people to
+consider whether this is the correct site. There should also be a barrier to
+prevent access by bots.
+
+## Decision
+
+We have decided to use basic authentication on the service in all environments
+apart from the public facing one. This will only be applicable to the
+environments hosted within the Rancher environment. The username and password
+will not be secret and will be included within the `README` of the application.
+
+## Consequences
+
+Consequences include:
+
+* Test sites will require basic authentication credentials to access

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connecting-to-services",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "private": true,
   "description": "Helping to connect people to appropriate services, meeting their time, location and accessibility needs.",
   "scripts": {

--- a/rancher-config/docker-compose.yml
+++ b/rancher-config/docker-compose.yml
@@ -5,28 +5,28 @@ services:
   c2s-frontend:
     image: "nhsuk/connecting-to-services:${DOCKER_IMAGE_TAG}"
     environment:
-      NODE_ENV: production
-      HOTJAR_ANALYTICS_TRACKING_ID: ${HOTJAR_ANALYTICS_TRACKING_ID}
-      GOOGLE_ANALYTICS_TRACKING_ID: ${GOOGLE_ID}
-      WEBTRENDS_ANALYTICS_TRACKING_ID: ${WEBTRENDS_ANALYTICS_TRACKING_ID}
       API_BASE_URL: 'http://nearby-services-api.nearby-services-api:3001'
+      GOOGLE_ANALYTICS_TRACKING_ID: ${GOOGLE_ID}
+      HOTJAR_ANALYTICS_TRACKING_ID: ${HOTJAR_ANALYTICS_TRACKING_ID}
+      NODE_ENV: production
+      WEBTRENDS_ANALYTICS_TRACKING_ID: ${WEBTRENDS_ANALYTICS_TRACKING_ID}
     labels:
+      io.rancher.container.pull_image: always
+      prometheus.monitoring: true
+      prometheus.port: 3000
+      traefik.backend: ${RANCHER_STACK_NAME}-connecting-to-services
       traefik.enable: true
       traefik.frontend.auth.basic: ${BASIC_AUTH}
       traefik.frontend.rule: $TRAEFIK_RULE
-      traefik.backend: ${RANCHER_STACK_NAME}-connecting-to-services
       traefik.port: 3000
-      prometheus.port: 3000
-      prometheus.monitoring: true
-      io.rancher.container.pull_image: always
     logging:
       driver: splunk
       options:
-        splunk-url: ${SPLUNK_HEC_URL}
-        splunk-token: ${SPLUNK_HEC_TOKEN}
+        splunk-format: json
         splunk-insecureskipverify: "true"
-        splunk-sourcetype: docker
         splunk-source: connecting-to-services
+        splunk-sourcetype: docker
+        splunk-token: ${SPLUNK_HEC_TOKEN}
+        splunk-url: ${SPLUNK_HEC_URL}
         splunk-verify-connection: "false"
         tag: "{{`{{.ImageName}} {{.Name}} {{.FullID}}`}}"
-        splunk-format: json

--- a/rancher-config/docker-compose.yml
+++ b/rancher-config/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       API_BASE_URL: 'http://nearby-services-api.nearby-services-api:3001'
     labels:
       traefik.enable: true
+      traefik.frontend.auth.basic: ${BASIC_AUTH}
       traefik.frontend.rule: $TRAEFIK_RULE
       traefik.backend: ${RANCHER_STACK_NAME}-connecting-to-services
       traefik.port: 3000


### PR DESCRIPTION
Adds basic auth to the service. Controlled via vault variables. By default all environments are protected. Overridden for environments that require access by all.