### PR TITLE
:bowtie: content change: search message, quotes, disambiguation

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -13,9 +13,6 @@ ignore:
     - nunjucks > chokidar > fsevents > node-pre-gyp > tar-pack > debug:
         reason: Not user facing
         expires: '2017-11-30T11:49:48.021Z'
-      brunch > chokidar > fsevents > node-pre-gyp > tar-pack > debug:
-        reason: Package is not executed from site.
-        expires: '2017-12-09T09:33:33.056Z'
     - nunjucks > chokidar > fsevents > node-pre-gyp > tar-pack > debug:
         reason: No upgrade path
         expires: '2017-12-09T09:33:33.056Z'
@@ -28,19 +25,22 @@ ignore:
     - node-pre-gyp > tar-pack > debug:
         reason: Not user facing
         expires: '2017-12-09T09:33:33.057Z'
+    - brunch > chokidar > fsevents > node-pre-gyp > tar-pack > debug:
+        reason: Package is not executed from site.
+        expires: '2017-12-09T09:33:33.056Z'
   'npm:tough-cookie:20170905':
     - nunjucks > chokidar > fsevents > node-pre-gyp > request > tough-cookie:
         reason: Not user facing
         expires: '2017-11-30T11:49:48.021Z'
-      brunch > chokidar > fsevents > node-pre-gyp > request > tough-cookie:
-        reason: Package is not executed from site.
-        expires: '2017-12-09T09:33:33.056Z'
     - nunjucks > chokidar > fsevents > node-pre-gyp > request > tough-cookie:
         reason: No upgrade path
         expires: '2017-12-09T09:33:33.057Z'
     - node-pre-gyp > request > tough-cookie:
         reason: Not user facing
         expires: '2017-12-09T09:33:33.057Z'
+    - brunch > chokidar > fsevents > node-pre-gyp > request > tough-cookie:
+        reason: Package is not executed from site.
+        expires: '2017-12-09T09:33:33.056Z'
   'npm:ms:20170412':
     - brunch > debug > ms:
         reason: Not user facing
@@ -52,4 +52,8 @@ ignore:
     - brunch > deppack > loggy > growl:
         reason: Not user facing
         expires: '2017-12-09T09:33:33.057Z'
+  'npm:tunnel-agent:20170305':
+    - node-sass > request > tunnel-agent:
+        reason: Ignore as no patch available
+        expires: '2017-12-20T11:59:37.194Z'
 patch: {}

--- a/app/lib/mapLink.js
+++ b/app/lib/mapLink.js
@@ -10,14 +10,15 @@ function joinAllTruthyValues(obj) {
 function addUrl(location, inputList) {
   return inputList.map((item) => {
     const address = joinAllTruthyValues(item.address);
-    const fullNameAndAddress =
-      `${item.name},${address}`;
+    const fullNameAndAddress = `${item.name},${address}`;
 
-    const encodedQuery = `saddr=${qs.escape(location)}&daddr=${qs.escape(fullNameAndAddress)}&near=${qs.escape(fullNameAndAddress)}`;
-    const mapUrl = `https://maps.google.com/maps?${encodedQuery}`;
-
+    const params = {
+      saddr: location,
+      daddr: fullNameAndAddress,
+      near: fullNameAndAddress
+    };
     // eslint-disable-next-line no-param-reassign
-    item.mapUrl = mapUrl;
+    item.mapUrl = `https://maps.google.com/maps?${qs.stringify(params)}`;
     return item;
   });
 }

--- a/app/lib/messages.js
+++ b/app/lib/messages.js
@@ -3,7 +3,7 @@ function invalidPostcodeMessage(location) {
 }
 
 function emptyPostcodeMessage() {
-  return 'You must insert a place or a postcode to find a pharmacy.';
+  return 'You must enter a town, city or postcode to find a pharmacy.';
 }
 
 function technicalProblems() {

--- a/app/lib/messages.js
+++ b/app/lib/messages.js
@@ -1,5 +1,5 @@
 function invalidPostcodeMessage(location) {
-  return `We can't find the postcode ${location.toLocaleUpperCase()}. Check the postcode is correct and try again.`;
+  return `We can't find the postcode '${location.toLocaleUpperCase()}'. Check the postcode is correct and try again.`;
 }
 
 function emptyPostcodeMessage() {

--- a/app/lib/setLocationsOnLocals.js
+++ b/app/lib/setLocationsOnLocals.js
@@ -1,6 +1,0 @@
-function setLocationsOnLocals(res, location) {
-  res.locals.location = location;
-  res.locals.displayLocation = location && location.split(',')[0];
-}
-
-module.exports = setLocationsOnLocals;

--- a/app/lib/setLocationsOnLocals.js
+++ b/app/lib/setLocationsOnLocals.js
@@ -1,0 +1,6 @@
+function setLocationsOnLocals(res, location) {
+  res.locals.location = location;
+  res.locals.displayLocation = location && location.split(',')[0];
+}
+
+module.exports = setLocationsOnLocals;

--- a/app/middleware/locals.js
+++ b/app/middleware/locals.js
@@ -4,6 +4,7 @@ module.exports = config =>
     res.locals.WEBTRENDS_ANALYTICS_TRACKING_ID = config.webtrendsId;
     res.locals.HOTJAR_ANALYTICS_TRACKING_ID = config.hotjarId;
     res.locals.SITE_ROOT = req.app.locals.SITE_ROOT;
+    res.locals.getDisplayLocation = () => res.locals.location && res.locals.location.split(',')[0];
 
     next();
   };

--- a/app/middleware/locationValidator.js
+++ b/app/middleware/locationValidator.js
@@ -7,12 +7,11 @@ const isNotEnglishPostcode = require('../lib/isNotEnglishPostcode');
 const englishPostcodeValidator = require('../lib/englishPostcodeValidator');
 const performPlaceSearch = require('./performPlaceSearch');
 const stringUtils = require('../lib/stringUtils');
-const setLocationsOnLocals = require('../lib/setLocationsOnLocals');
 
 function validateEnglishPostcode(req, res, next) {
   const location = res.locals.location;
   const validationResult = englishPostcodeValidator(location);
-  setLocationsOnLocals(res, validationResult.alteredLocation);
+  res.locals.location = validationResult.alteredLocation;
   if (validationResult.errorMessage) {
     routeHelper.renderFindHelpPage(req, res, location, 'Non-English postcode', validationResult.errorMessage);
   } else {
@@ -23,7 +22,7 @@ function validateEnglishPostcode(req, res, next) {
 function validatePlaceLocation(req, res, next, location) {
   const safeString = stringUtils.removeNonAlphabeticAndWhitespace(location);
   if (safeString) {
-    setLocationsOnLocals(res, safeString);
+    res.locals.location = safeString;
     performPlaceSearch(req, res, next);
   } else {
     routeHelper.renderFindHelpPage(req, res, location, 'No location entered', messages.emptyPostcodeMessage());
@@ -32,7 +31,7 @@ function validatePlaceLocation(req, res, next, location) {
 
 function validateLocation(req, res, next) {
   if (skipLatLongLookup(res)) {
-    setLocationsOnLocals(res, stringUtils.removeNonAddressCharacters(res.locals.location));
+    res.locals.location = stringUtils.removeNonAddressCharacters(res.locals.location);
     next();
   } else {
     const location = res.locals.location && res.locals.location.trim();

--- a/app/middleware/locationValidator.js
+++ b/app/middleware/locationValidator.js
@@ -7,11 +7,12 @@ const isNotEnglishPostcode = require('../lib/isNotEnglishPostcode');
 const englishPostcodeValidator = require('../lib/englishPostcodeValidator');
 const performPlaceSearch = require('./performPlaceSearch');
 const stringUtils = require('../lib/stringUtils');
+const setLocationsOnLocals = require('../lib/setLocationsOnLocals');
 
 function validateEnglishPostcode(req, res, next) {
   const location = res.locals.location;
   const validationResult = englishPostcodeValidator(location);
-  res.locals.location = validationResult.alteredLocation;
+  setLocationsOnLocals(res, validationResult.alteredLocation);
   if (validationResult.errorMessage) {
     routeHelper.renderFindHelpPage(req, res, location, 'Non-English postcode', validationResult.errorMessage);
   } else {
@@ -22,7 +23,7 @@ function validateEnglishPostcode(req, res, next) {
 function validatePlaceLocation(req, res, next, location) {
   const safeString = stringUtils.removeNonAlphabeticAndWhitespace(location);
   if (safeString) {
-    res.locals.location = safeString;
+    setLocationsOnLocals(res, safeString);
     performPlaceSearch(req, res, next);
   } else {
     routeHelper.renderFindHelpPage(req, res, location, 'No location entered', messages.emptyPostcodeMessage());
@@ -31,7 +32,7 @@ function validatePlaceLocation(req, res, next, location) {
 
 function validateLocation(req, res, next) {
   if (skipLatLongLookup(res)) {
-    res.locals.location = stringUtils.removeNonAddressCharacters(res.locals.location);
+    setLocationsOnLocals(res, stringUtils.removeNonAddressCharacters(res.locals.location));
     next();
   } else {
     const location = res.locals.location && res.locals.location.trim();

--- a/app/middleware/performPlaceSearch.js
+++ b/app/middleware/performPlaceSearch.js
@@ -2,7 +2,6 @@ const log = require('../lib/logger');
 const locate = require('../lib/locate');
 const sortPlace = require('../lib/sortPlace');
 const getAddress = require('../lib/getAddress');
-const setLocationsOnLocals = require('../lib/setLocationsOnLocals');
 const renderer = require('./renderer');
 const createPlaceViewModel = require('./createPlaceViewModel');
 const placeSearches = require('../lib/promCounters').placeSearches;
@@ -44,7 +43,7 @@ async function getPlaces(req, res, next) {
     logZeroResults(places, location);
     if (places.length === 1) {
       res.locals.coordinates = getCoordinates(places[0]);
-      setLocationsOnLocals(res, getAddress(places[0]));
+      res.locals.location = getAddress(places[0]);
       next();
     } else {
       incrementDisambiguationViews(places);

--- a/app/middleware/performPlaceSearch.js
+++ b/app/middleware/performPlaceSearch.js
@@ -2,6 +2,7 @@ const log = require('../lib/logger');
 const locate = require('../lib/locate');
 const sortPlace = require('../lib/sortPlace');
 const getAddress = require('../lib/getAddress');
+const setLocationsOnLocals = require('../lib/setLocationsOnLocals');
 const renderer = require('./renderer');
 const createPlaceViewModel = require('./createPlaceViewModel');
 const placeSearches = require('../lib/promCounters').placeSearches;
@@ -35,7 +36,7 @@ function getCoordinates(place) {
 }
 
 async function getPlaces(req, res, next) {
-  const location = req.query.location;
+  const location = res.locals.location;
   try {
     let places = await locate.byPlace(location, 100);
     placeSearches.inc(1);
@@ -43,7 +44,7 @@ async function getPlaces(req, res, next) {
     logZeroResults(places, location);
     if (places.length === 1) {
       res.locals.coordinates = getCoordinates(places[0]);
-      res.locals.location = getAddress(places[0]);
+      setLocationsOnLocals(res, getAddress(places[0]));
       next();
     } else {
       incrementDisambiguationViews(places);

--- a/app/middleware/prerender.js
+++ b/app/middleware/prerender.js
@@ -2,7 +2,6 @@ const mapLink = require('../lib/mapLink');
 
 function results(req, res, next) {
   const location = res.locals.location;
-
   res.locals.nearbyServices = mapLink.addUrl(location, res.locals.nearbyServices);
   res.locals.openServices = mapLink.addUrl(location, res.locals.openServices);
 

--- a/app/middleware/setLocals.js
+++ b/app/middleware/setLocals.js
@@ -2,6 +2,7 @@ const backLinkUtils = require('../lib/backLinkUtils');
 const setLocationsOnLocals = require('../lib/setLocationsOnLocals');
 
 function fromRequest(req, res, next) {
+  res.locals.req_location = req.query.location;
   setLocationsOnLocals(res, req.query.location);
   res.locals.locationLabel = 'Enter a town, city or postcode';
   res.locals.coordinates = {

--- a/app/middleware/setLocals.js
+++ b/app/middleware/setLocals.js
@@ -1,7 +1,8 @@
 const backLinkUtils = require('../lib/backLinkUtils');
+const setLocationsOnLocals = require('../lib/setLocationsOnLocals');
 
 function fromRequest(req, res, next) {
-  res.locals.location = req.query.location;
+  setLocationsOnLocals(res, req.query.location);
   res.locals.locationLabel = 'Enter a town, city or postcode';
   res.locals.coordinates = {
     latitude: req.query.latitude,

--- a/app/middleware/setLocals.js
+++ b/app/middleware/setLocals.js
@@ -2,7 +2,7 @@ const backLinkUtils = require('../lib/backLinkUtils');
 
 function fromRequest(req, res, next) {
   res.locals.location = req.query.location;
-  res.locals.locationLabel = 'Enter a place or a postcode';
+  res.locals.locationLabel = 'Enter a town, city or postcode';
   res.locals.coordinates = {
     latitude: req.query.latitude,
     longitude: req.query.longitude,

--- a/app/middleware/setLocals.js
+++ b/app/middleware/setLocals.js
@@ -1,9 +1,8 @@
 const backLinkUtils = require('../lib/backLinkUtils');
-const setLocationsOnLocals = require('../lib/setLocationsOnLocals');
 
 function fromRequest(req, res, next) {
   res.locals.req_location = req.query.location;
-  setLocationsOnLocals(res, req.query.location);
+  res.locals.location = req.query.location;
   res.locals.locationLabel = 'Enter a town, city or postcode';
   res.locals.coordinates = {
     latitude: req.query.latitude,

--- a/app/views/find-help.nunjucks
+++ b/app/views/find-help.nunjucks
@@ -4,7 +4,7 @@
 <h1 class="local-header--title--question">Find a pharmacy</h1>
 {% endblock %}
 
-{% block pageTitle %}Find a pharmacy{% if errorMessage %} - We can't find the postcode {{location}}{% endif %}{% endblock %}
+{% block pageTitle %}Find a pharmacy{% if errorMessage %} - We can't find the postcode '{{location}}'{% endif %}{% endblock %}
 
 {% block content %}
 

--- a/app/views/includes/no-place-results.nunjucks
+++ b/app/views/includes/no-place-results.nunjucks
@@ -1,6 +1,6 @@
 <div class="results">
   <div class="results-block results-block--none">
-    <h2 class="results__header results__header--none">There are no matches for place {{ location }}</h2>
+    <h2 class="results__header results__header--none">There are no matches for place '{{ location }}'</h2>
     <div class="results__none-content">
       <p>This service only provides information about pharmacies in England.</p>
       <p>You might be getting this result because you live in Scotland, Wales or Northern Ireland, or because you live near a border with one of those countries. It could also be because you live on the Isle of Man.</p>

--- a/app/views/includes/no-place-results.nunjucks
+++ b/app/views/includes/no-place-results.nunjucks
@@ -1,6 +1,6 @@
 <div class="results">
   <div class="results-block results-block--none">
-    <h2 class="results__header results__header--none">There are no matches for place '{{ location }}'</h2>
+    <h2 class="results__header results__header--none">We can't find '{{ location }}'</h2>
     <div class="results__none-content">
       <p>This service only provides information about pharmacies in England.</p>
       <p>You might be getting this result because you live in Scotland, Wales or Northern Ireland, or because you live near a border with one of those countries. It could also be because you live on the Isle of Man.</p>

--- a/app/views/includes/no-place-results.nunjucks
+++ b/app/views/includes/no-place-results.nunjucks
@@ -1,4 +1,6 @@
-<div class="results">
+<div class="grid-row">
+  <h1 class="sr-only">Search results</h1>
+  <div class="results">
   <div class="results-block results-block--none">
     <h2 class="results__header results__header--none">We can't find '{{ location }}'</h2>
     <div class="results__none-content">
@@ -10,4 +12,5 @@
       <p><a href="https://www.gov.im/categories/health-and-wellbeing/pharmacy">Find pharmacies on the Isle of Man government website</a>.</p>
     </div>
   </div>
+</div>
 </div>

--- a/app/views/includes/place-results.nunjucks
+++ b/app/views/includes/place-results.nunjucks
@@ -1,4 +1,5 @@
-
+<div class="reading-width places">
+  <h1 class="sr-only">Search results</h1>
   <h2 class="results__header">
     We found {{places.length}} places that match '{{location}}'
   </h2>
@@ -13,3 +14,4 @@
     </li>
   {% endfor %}
   </ol>
+  </div>

--- a/app/views/includes/place-results.nunjucks
+++ b/app/views/includes/place-results.nunjucks
@@ -1,7 +1,9 @@
 
   <h2 class="results__header">
-    There are {{places.length}} places matching {{location}}. <br/>
-    Please select your location from the list below to continue.
+    We found {{places.length}} places that match '{{location}}'
+  </h2>
+  <h2 class="results__header">
+    Choose one of the following:
   </h2>
   <ol class="results">
   {% for place in places %}

--- a/app/views/places.nunjucks
+++ b/app/views/places.nunjucks
@@ -8,18 +8,9 @@
 
 {% block content %}
 <a href="{{ SITE_ROOT }}/" class="link-back">Back to find a pharmacy</a>
-
-<div class="reading-width places">
-
-  <h1 class="sr-only">Search results</h1>
-
-  {% if places.length === 0 %}
-
-    {% include "includes/no-place-results.nunjucks" %}
-
-  {% elif places.length > 0 %}
-    {% include "includes/place-results.nunjucks" %}
-  {% endif %}
-</div>
-
+{% if places.length === 0 %}
+  {% include "includes/no-place-results.nunjucks" %}
+{% elif places.length > 0 %}
+  {% include "includes/place-results.nunjucks" %}
+{% endif %}
 {% endblock %}

--- a/app/views/results.nunjucks
+++ b/app/views/results.nunjucks
@@ -1,6 +1,6 @@
 {% extends 'layout.nunjucks' %}
 
-{% block pageTitle %}Pharmacies near {{ location }}{% endblock %}
+{% block pageTitle %}Pharmacies near {{ displayLocation }}{% endblock %}
 
 {% block meta %}
 <meta name="DCSext.ServiceName" content="pharmacies" />
@@ -21,7 +21,7 @@
 
     <ol class="results">
       <li class="results__item results__item--nearest">
-        <h2 class="results__header results__header--nearest">Nearest open pharmacy to {{ location }}</h2>
+        <h2 class="results__header results__header--nearest">Nearest open pharmacy to {{ displayLocation }}</h2>
         <div class="results__details results__details-nearest column--two-thirds results__details--column">
           {% set service = openServices[0] %}
           {% include "includes/result-item.nunjucks" %}

--- a/app/views/results.nunjucks
+++ b/app/views/results.nunjucks
@@ -1,6 +1,6 @@
 {% extends 'layout.nunjucks' %}
 
-{% block pageTitle %}Pharmacies near {{ displayLocation }}{% endblock %}
+{% block pageTitle %}Pharmacies near {{ getDisplayLocation() }}{% endblock %}
 
 {% block meta %}
 <meta name="DCSext.ServiceName" content="pharmacies" />
@@ -21,7 +21,7 @@
 
     <ol class="results">
       <li class="results__item results__item--nearest">
-        <h2 class="results__header results__header--nearest">Nearest open pharmacy to {{ displayLocation }}</h2>
+        <h2 class="results__header results__header--nearest">Nearest open pharmacy to {{ getDisplayLocation() }}</h2>
         <div class="results__details results__details-nearest column--two-thirds results__details--column">
           {% set service = openServices[0] %}
           {% include "includes/result-item.nunjucks" %}

--- a/test/integration/locate.js
+++ b/test/integration/locate.js
@@ -4,7 +4,7 @@ const lookup = require('../../app/lib/locate');
 const expect = chai.expect;
 
 describe('locate', function testWithTimeout() {
-  this.timeout(5000);
+  this.timeout(15000);
   describe('byPostcode', () => {
     it('should return lat long for valid England postcode', async () => {
       const validPostcode = 'BD24 9PT';

--- a/test/integration/locate.js
+++ b/test/integration/locate.js
@@ -3,7 +3,8 @@ const lookup = require('../../app/lib/locate');
 
 const expect = chai.expect;
 
-describe('locate', () => {
+describe('locate', function testWithTimeout() {
+  this.timeout(5000);
   describe('byPostcode', () => {
     it('should return lat long for valid England postcode', async () => {
       const validPostcode = 'BD24 9PT';

--- a/test/integration/resultsPagePlace.js
+++ b/test/integration/resultsPagePlace.js
@@ -41,7 +41,7 @@ describe('The place results page', () => {
         const $ = cheerio.load(res.text);
 
         expect($('.results__header--nearest').text())
-          .to.equal('Nearest open pharmacy to Midsomer Norton, Bath and North East Somerset, BA3');
+          .to.equal('Nearest open pharmacy to Midsomer Norton');
 
         expect($('.results__header--nearby').text())
           .to.equal('Other pharmacies nearby');
@@ -59,7 +59,7 @@ describe('The place results page', () => {
 
         expect($('.link-back').text()).to.equal('Back to find a pharmacy');
         expect($('.link-back').attr('href')).to.equal(`${constants.SITE_ROOT}/`);
-        expect($('title').text()).to.equal('Pharmacies near Midsomer Norton, Bath and North East Somerset, BA3 - NHS.UK');
+        expect($('title').text()).to.equal('Pharmacies near Midsomer Norton - NHS.UK');
         done();
       });
   });

--- a/test/integration/resultsPagePlace.js
+++ b/test/integration/resultsPagePlace.js
@@ -66,21 +66,21 @@ describe('The place results page', () => {
 
   it('should return disambiguation page for non unique place search', (done) => {
     const multiPlaceResponse = getSampleResponse('postcodesio-responses/multiplePlaceResult.json');
-
+    const multiPlaceTerm = 'multiresult';
     nock('https://api.postcodes.io')
-      .get('/places?q=multiresult&limit=100')
+      .get(`/places?q=${multiPlaceTerm}&limit=100`)
       .times(1)
       .reply(200, multiPlaceResponse);
 
     chai.request(server)
       .get(resultsRoute)
-      .query({ location: 'multiresult' })
+      .query({ location: multiPlaceTerm })
       .end((err, res) => {
         iExpect.htmlWith200Status(err, res);
         const $ = cheerio.load(res.text);
 
         expect($('.results__header').text())
-          .to.include('We found 3 places that match \'multiresult\'');
+          .to.include(`We found 3 places that match '${multiPlaceTerm}'`);
 
         expect($('.link-back').text()).to.equal('Back to find a pharmacy');
         expect($('.link-back').attr('href')).to.equal(`${constants.SITE_ROOT}/`);
@@ -92,7 +92,7 @@ describe('The place results page', () => {
 
   function expectSearchAgainPage($) {
     expect($('.error-summary-heading').text())
-      .to.contain('You must insert a place or a postcode to find a pharmacy.');
+      .to.contain('You must enter a town, city or postcode to find a pharmacy.');
   }
 
   it('should return search page for empty search', (done) => {
@@ -110,18 +110,19 @@ describe('The place results page', () => {
   });
 
   it('should return no results page for unknown place search', (done) => {
+    const noResultsTerm = 'noresults';
     nock('https://api.postcodes.io')
-      .get('/places?q=noresults&limit=100')
+      .get(`/places?q=${noResultsTerm}&limit=100`)
       .times(1)
       .reply(200, { status: 200, result: [] });
 
     chai.request(server)
       .get(resultsRoute)
-      .query({ location: 'noresults' })
+      .query({ location: noResultsTerm })
       .end((err, res) => {
         iExpect.htmlWith200Status(err, res);
         const $ = cheerio.load(res.text);
-        expect($('.results__header--none').text()).to.be.equal('We can\'t find \'noresults\'');
+        expect($('.results__header--none').text()).to.be.equal(`We can't find '${noResultsTerm}'`);
         done();
       });
   });

--- a/test/integration/resultsPagePlace.js
+++ b/test/integration/resultsPagePlace.js
@@ -80,7 +80,7 @@ describe('The place results page', () => {
         const $ = cheerio.load(res.text);
 
         expect($('.results__header').text())
-          .to.include('There are 3 places matching multiresult');
+          .to.include('We found 3 places that match \'multiresult\'');
 
         expect($('.link-back').text()).to.equal('Back to find a pharmacy');
         expect($('.link-back').attr('href')).to.equal(`${constants.SITE_ROOT}/`);
@@ -103,7 +103,7 @@ describe('The place results page', () => {
         iExpect.htmlWith200Status(err, res);
         const $ = cheerio.load(res.text);
         expectSearchAgainPage($);
-        expect($('title').text()).to.equal('Find a pharmacy - We can\'t find the postcode  - NHS.UK');
+        expect($('title').text()).to.equal('Find a pharmacy - We can\'t find the postcode \'\' - NHS.UK');
 
         done();
       });
@@ -134,7 +134,7 @@ describe('The place results page', () => {
         iExpect.htmlWith200Status(err, res);
         const $ = cheerio.load(res.text);
         expectSearchAgainPage($);
-        expect($('title').text()).to.equal('Find a pharmacy - We can\'t find the postcode !@£$% - NHS.UK');
+        expect($('title').text()).to.equal('Find a pharmacy - We can\'t find the postcode \'!@£$%\' - NHS.UK');
 
         done();
       });

--- a/test/integration/resultsPagePlace.js
+++ b/test/integration/resultsPagePlace.js
@@ -121,7 +121,7 @@ describe('The place results page', () => {
       .end((err, res) => {
         iExpect.htmlWith200Status(err, res);
         const $ = cheerio.load(res.text);
-        expect($('.results__header--none').text()).to.be.equal('There are no matches for place \'noresults\'');
+        expect($('.results__header--none').text()).to.be.equal('We can\'t find \'noresults\'');
         done();
       });
   });

--- a/test/integration/resultsPagePlace.js
+++ b/test/integration/resultsPagePlace.js
@@ -121,7 +121,7 @@ describe('The place results page', () => {
       .end((err, res) => {
         iExpect.htmlWith200Status(err, res);
         const $ = cheerio.load(res.text);
-        expect($('.results__header--none').text()).to.be.equal('There are no matches for place noresults');
+        expect($('.results__header--none').text()).to.be.equal('There are no matches for place \'noresults\'');
         done();
       });
   });

--- a/test/integration/resultsPagePostcode.js
+++ b/test/integration/resultsPagePostcode.js
@@ -200,7 +200,7 @@ describe('The results page error handling', () => {
 
           expect($('.error-summary-heading').text()).to
             .contain(messages.invalidPostcodeMessage(invalidPostcodePassingRegex));
-          expect($('title').text()).to.equal(`Find a pharmacy - We can't find the postcode ${invalidPostcodePassingRegex} - NHS.UK`);
+          expect($('title').text()).to.equal(`Find a pharmacy - We can't find the postcode '${invalidPostcodePassingRegex}' - NHS.UK`);
           done();
         });
     }

--- a/test/lib/expectations.js
+++ b/test/lib/expectations.js
@@ -14,7 +14,7 @@ function findHelpPageInvalidEntry($) {
 
 function findHelpPage($) {
   findHelpPageBase($);
-  expect($('label[for=location]').text()).to.contain('Enter a place or a postcode');
+  expect($('label[for=location]').text()).to.contain('Enter a town, city or postcode');
 }
 
 function htmlWith200Status(err, res) {

--- a/test/unit/lib/messages.js
+++ b/test/unit/lib/messages.js
@@ -7,7 +7,7 @@ describe('messages', () => {
   it('should have a message for an invalid postcode where the location has been capitalised', () => {
     const location = 'something';
     const expectedMessage =
-      `We can't find the postcode ${location.toLocaleUpperCase()}. Check the postcode is correct and try again.`;
+      `We can't find the postcode '${location.toLocaleUpperCase()}'. Check the postcode is correct and try again.`;
 
     const message = messages.invalidPostcodeMessage(location);
 

--- a/test/unit/lib/messages.js
+++ b/test/unit/lib/messages.js
@@ -18,7 +18,7 @@ describe('messages', () => {
   it('should have an error message for when nothing has been entered to search with', () => {
     const message = messages.emptyPostcodeMessage();
 
-    expect(message).to.equal('You must insert a place or a postcode to find a pharmacy.');
+    expect(message).to.equal('You must enter a town, city or postcode to find a pharmacy.');
   });
 
   it('should have an error message for technical problems', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,7 +39,7 @@ acorn@^4.0.3:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
 
-acorn@^5.1.1:
+acorn@^5.1.1, acorn@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.2.1.tgz#317ac7821826c22c702d66189ab8359675f135d7"
 
@@ -58,7 +58,7 @@ ajv@^4.9.1:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-ajv@^5.1.0, ajv@^5.2.0, ajv@^5.2.3:
+ajv@^5.1.0, ajv@^5.2.0, ajv@^5.2.3, ajv@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.3.0.tgz#4414ff74a50879c208ee5fdc826e32c303549eda"
   dependencies:
@@ -1623,7 +1623,7 @@ eslint-watch@^3.1.2:
     text-table "^0.2.0"
     unicons "0.0.3"
 
-eslint@^4.0.0, eslint@^4.6.1:
+eslint@^4.0.0:
   version "4.10.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.10.0.tgz#f25d0d7955c81968c2309aa5c9a229e045176bb7"
   dependencies:
@@ -1665,11 +1665,60 @@ eslint@^4.0.0, eslint@^4.6.1:
     table "^4.0.1"
     text-table "~0.2.0"
 
+eslint@^4.6.1:
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.11.0.tgz#39a8c82bc0a3783adf5a39fa27fdd9d36fac9a34"
+  dependencies:
+    ajv "^5.3.0"
+    babel-code-frame "^6.22.0"
+    chalk "^2.1.0"
+    concat-stream "^1.6.0"
+    cross-spawn "^5.1.0"
+    debug "^3.0.1"
+    doctrine "^2.0.0"
+    eslint-scope "^3.7.1"
+    espree "^3.5.2"
+    esquery "^1.0.0"
+    estraverse "^4.2.0"
+    esutils "^2.0.2"
+    file-entry-cache "^2.0.0"
+    functional-red-black-tree "^1.0.1"
+    glob "^7.1.2"
+    globals "^9.17.0"
+    ignore "^3.3.3"
+    imurmurhash "^0.1.4"
+    inquirer "^3.0.6"
+    is-resolvable "^1.0.0"
+    js-yaml "^3.9.1"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.3.0"
+    lodash "^4.17.4"
+    minimatch "^3.0.2"
+    mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    optionator "^0.8.2"
+    path-is-inside "^1.0.2"
+    pluralize "^7.0.0"
+    progress "^2.0.0"
+    require-uncached "^1.0.3"
+    semver "^5.3.0"
+    strip-ansi "^4.0.0"
+    strip-json-comments "~2.0.1"
+    table "^4.0.1"
+    text-table "~0.2.0"
+
 espree@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.1.tgz#0c988b8ab46db53100a1954ae4ba995ddd27d87e"
   dependencies:
     acorn "^5.1.1"
+    acorn-jsx "^3.0.0"
+
+espree@^3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.2.tgz#756ada8b979e9dcfcdb30aad8d1a9304a905e1ca"
+  dependencies:
+    acorn "^5.2.1"
     acorn-jsx "^3.0.0"
 
 esprima@^2.6.0:
@@ -3079,6 +3128,10 @@ json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
 
+json-stable-stringify-without-jsonify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
+
 json-stable-stringify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
@@ -3702,8 +3755,8 @@ node-pre-gyp@^0.6.36:
     tar-pack "^3.4.0"
 
 node-sass@^4.5.3:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.6.0.tgz#1a54f5f4502e3cde310a26d6346266fd667271d9"
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.7.1.tgz#bec978ab33b5cf56825bf72922323a56ebaf4f66"
   dependencies:
     async-foreach "^0.1.3"
     chalk "^1.1.1"
@@ -3720,9 +3773,10 @@ node-sass@^4.5.3:
     nan "^2.3.2"
     node-gyp "^3.3.1"
     npmlog "^4.0.0"
-    request "^2.79.0"
+    request "~2.79.0"
     sass-graph "^2.2.4"
     stdout-stream "^1.4.0"
+    "true-case-path" "^1.0.2"
 
 node-sass@~3.8.0:
   version "3.8.0"
@@ -4304,6 +4358,10 @@ proxy-addr@~2.0.2:
     forwarded "~0.1.2"
     ipaddr.js "1.5.2"
 
+proxy-from-env@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
+
 proxyquire@^1.7.10:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/proxyquire/-/proxyquire-1.8.0.tgz#02d514a5bed986f04cbb2093af16741535f79edc"
@@ -4584,7 +4642,7 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-request@2, request@^2.61.0, request@^2.79.0, request@^2.81.0:
+request@2, request@^2.61.0, request@^2.81.0:
   version "2.83.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.83.0.tgz#ca0b65da02ed62935887808e6f510381034e3356"
   dependencies:
@@ -4611,7 +4669,7 @@ request@2, request@^2.61.0, request@^2.79.0, request@^2.81.0:
     tunnel-agent "^0.6.0"
     uuid "^3.1.0"
 
-request@2.79.0:
+request@2.79.0, request@~2.79.0:
   version "2.79.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de"
   dependencies:
@@ -4993,10 +5051,11 @@ snyk-mvn-plugin@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/snyk-mvn-plugin/-/snyk-mvn-plugin-1.1.0.tgz#6ad3fb670cd22972094f065ab99b90d286c8ad6f"
 
-snyk-nuget-plugin@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/snyk-nuget-plugin/-/snyk-nuget-plugin-1.1.1.tgz#f23534ae9376075627321d3ecada50733e77918b"
+snyk-nuget-plugin@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/snyk-nuget-plugin/-/snyk-nuget-plugin-1.3.1.tgz#6b1a5d37ca2d5d2b311fc51de03720e23a0a85d4"
   dependencies:
+    debug "^3.1.0"
     es6-promise "^4.1.1"
     xml2js "^0.4.17"
     zip "^1.2.0"
@@ -5072,8 +5131,8 @@ snyk-try-require@^1.1.1, snyk-try-require@^1.2.0:
     then-fs "^2.0.0"
 
 snyk@^1.40.2:
-  version "1.49.1"
-  resolved "https://registry.yarnpkg.com/snyk/-/snyk-1.49.1.tgz#1bed0aace409b831e719516669c6b3d497171966"
+  version "1.49.4"
+  resolved "https://registry.yarnpkg.com/snyk/-/snyk-1.49.4.tgz#e47829b609ad1179f63d784947ebcb748021d6e2"
   dependencies:
     abbrev "^1.0.7"
     ansi-escapes "^1.3.0"
@@ -5086,13 +5145,14 @@ snyk@^1.40.2:
     needle "^2.0.1"
     open "^0.0.5"
     os-name "^1.0.3"
+    proxy-from-env "^1.0.0"
     semver "^5.1.0"
     snyk-config "1.0.1"
     snyk-go-plugin "1.3.8"
     snyk-gradle-plugin "1.2.0"
     snyk-module "1.8.1"
     snyk-mvn-plugin "1.1.0"
-    snyk-nuget-plugin "1.1.1"
+    snyk-nuget-plugin "1.3.1"
     snyk-policy "1.7.1"
     snyk-python-plugin "1.4.0"
     snyk-recursive-readdir "^2.0.0"
@@ -5517,8 +5577,8 @@ ucurry@0.0.1:
   resolved "https://registry.yarnpkg.com/ucurry/-/ucurry-0.0.1.tgz#0ec72e672ec2f8d4f589f1cd568fb172e5f84ff0"
 
 uglify-es@^3.1.8:
-  version "3.1.8"
-  resolved "https://registry.yarnpkg.com/uglify-es/-/uglify-es-3.1.8.tgz#2f21a56871d6354dcc21469cc034c3967f14c5b1"
+  version "3.1.10"
+  resolved "https://registry.yarnpkg.com/uglify-es/-/uglify-es-3.1.10.tgz#f1840c3b52771d17555a02ce158cf46f689384bd"
   dependencies:
     commander "~2.11.0"
     source-map "~0.6.1"


### PR DESCRIPTION
`Enter a place or a postcode` on initial search screen is now `Enter a town, city or postcode`.
If a term is not found in a search, the search term is now surrounded by single quotes on the error page.
`There are n places matching x` is now `We found n places that match 'y'`.
`Please select your location from the list below to continue.` is now `Choose one of the following:`. The text has moved from the header into a styled `p` tag.
The search term on the results page is the cleansed search term rather than a string built of the address returned from the lookup.
