### PR TITLE
:eyes: display correct search field label when no postcode results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 0.19.1 / 2017-11-28
 ===================
 - Fix map link for `your location` searches
+- Display correct search field label when no postcode result
 
 0.19.0 / 2017-11-23
 ===================

--- a/app/middleware/routeHelper.js
+++ b/app/middleware/routeHelper.js
@@ -1,18 +1,10 @@
 const renderer = require('./renderer');
 const log = require('../lib/logger');
-const messages = require('../lib/messages');
-
-function setLocationLabel(res, location) {
-  if (location) {
-    res.locals.locationLabel = messages.emptyPostcodeMessage();
-  }
-}
 
 function renderFindHelpPage(req, res, message, errorMessage) {
   const location = res.locals.location;
   log.info({ locationValidationResponse: { location } }, message);
   res.locals.errorMessage = errorMessage;
-  setLocationLabel(res, location);
   renderer.findHelp(req, res);
 }
 

--- a/test/integration/resultsPagePlace.js
+++ b/test/integration/resultsPagePlace.js
@@ -114,7 +114,7 @@ describe('The place results page', () => {
         const $ = cheerio.load(res.text);
         expectSearchAgainPage($);
         expect($('title').text()).to.equal('Find a pharmacy - We can\'t find the postcode \'\' - NHS.UK');
-
+        expect($('.form-label-bold').text()).to.equal('Enter a town, city or postcode in England');
         done();
       });
   });
@@ -151,7 +151,7 @@ describe('The place results page', () => {
         const $ = cheerio.load(res.text);
         expectSearchAgainPage($);
         expect($('title').text()).to.equal('Find a pharmacy - We can\'t find the postcode \'!@£$%\' - NHS.UK');
-
+        expect($('.form-label-bold').text()).to.equal('Enter a town, city or postcode in England');
         done();
       });
   });

--- a/test/integration/resultsPagePlace.js
+++ b/test/integration/resultsPagePlace.js
@@ -15,6 +15,12 @@ const resultsRoute = `${constants.SITE_ROOT}/results`;
 const numberOfOpenResults = constants.numberOfOpenResults;
 const numberOfNearbyResults = constants.numberOfNearbyResultsToRequest;
 
+function expectSearchAgainPage($) {
+  expect($('.error-summary-heading').text())
+    .to.contain('You must enter a town, city or postcode to find a pharmacy.');
+  expect($('.form-label-bold').text()).to.equal('Enter a town, city or postcode in England');
+}
+
 describe('The place results page', () => {
   it('should return list of pharmacies for unique place search', (done) => {
     const singlePlaceResponse = getSampleResponse('postcodesio-responses/singlePlaceResult.json');
@@ -100,11 +106,6 @@ describe('The place results page', () => {
       });
   });
 
-  function expectSearchAgainPage($) {
-    expect($('.error-summary-heading').text())
-      .to.contain('You must enter a town, city or postcode to find a pharmacy.');
-  }
-
   it('should return search page for empty search', (done) => {
     chai.request(server)
       .get(resultsRoute)
@@ -114,7 +115,6 @@ describe('The place results page', () => {
         const $ = cheerio.load(res.text);
         expectSearchAgainPage($);
         expect($('title').text()).to.equal('Find a pharmacy - We can\'t find the postcode \'\' - NHS.UK');
-        expect($('.form-label-bold').text()).to.equal('Enter a town, city or postcode in England');
         done();
       });
   });
@@ -151,7 +151,6 @@ describe('The place results page', () => {
         const $ = cheerio.load(res.text);
         expectSearchAgainPage($);
         expect($('title').text()).to.equal('Find a pharmacy - We can\'t find the postcode \'!@£$%\' - NHS.UK');
-        expect($('.form-label-bold').text()).to.equal('Enter a town, city or postcode in England');
         done();
       });
   });

--- a/test/integration/resultsPagePostcode.js
+++ b/test/integration/resultsPagePostcode.js
@@ -221,6 +221,7 @@ describe('The results page error handling', () => {
           expect($('.error-summary-heading').text()).to
             .contain(messages.invalidPostcodeMessage(invalidPostcodePassingRegex));
           expect($('title').text()).to.equal(`Find a pharmacy - We can't find the postcode '${invalidPostcodePassingRegex}' - NHS.UK`);
+          expect($('.form-label-bold').text()).to.equal('Enter a town, city or postcode in England');
           done();
         });
     }


### PR DESCRIPTION
<!--
Thanks for wanting to contribute to this repository.

In order for the changes to be integrated into the repo with as little friction
as possible please follow the guidance here. This includes completing all
sections as fully as possible.
Prior to creating a Pull Request, please ensure there is an open issue for the
changes you wish to make. This will provide visibility to others early in the
process. Potentially other people will wish to help out. It also allows us to
validate the change is inline with our vision for the product.

Provide a general summary of your changes in the Title
-->

## Description
Label was incorrect for no postcode results - it was 'You must enter a town, city or postcode to find a pharmacy.' rather than 'Enter a town, city or postcode in England'. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->
- [ ] An [ADR](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions)
- [x] New and/or updated tests
- [x] Changes log in `CHANGELOG`
