### PR TITLE
:bug: Correct reference for GA Id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-0.24.0 / 2018-01-02
+0.24.0 / 2018-01-09
 ===================
 - Update styles to fall in line with live styles
 - Update npm dependencies
+- Correct reference to `GOOGLE_ANALYTICS_TRACKING_ID`
 
 0.23.0 / 2017-12-14
 ===================

--- a/rancher-config/docker-compose.yml
+++ b/rancher-config/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     image: "nhsuk/connecting-to-services:${DOCKER_IMAGE_TAG}"
     environment:
       API_BASE_URL: 'http://nearby-services-api.nearby-services-api:3001'
-      GOOGLE_ANALYTICS_TRACKING_ID: ${GOOGLE_ID}
+      GOOGLE_ANALYTICS_TRACKING_ID: ${GOOGLE_ANALYTICS_TRACKING_ID}
       HOTJAR_ANALYTICS_TRACKING_ID: ${HOTJAR_ANALYTICS_TRACKING_ID}
       NODE_ENV: production
       WEBTRENDS_ANALYTICS_TRACKING_ID: ${WEBTRENDS_ANALYTICS_TRACKING_ID}


### PR DESCRIPTION
This change fixes the problem of the deployed application not having the correct mapping for Google Analytics Id, resulting in no GA script being included in the app and thus no GA tracking.
Previously there were entries for both `GOOGLE_ANALYTICS_TRACKING_ID` and `GOOGLE_ID` in the vault. However, to remove duplication and increase consistency across Tracking Ids all Tracking Ids are now `XXXXXXX_ANALYTICS_TRACKING_ID`.