### PR TITLE
:accept: Extract displayOpenResults into shareable module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Split the display of open and nearby results so they each have a view, toggled via query string parameter `open`
 - Revamped results page visuals for open and nearby only views
 - Update npm dependencies
+- Fixed bug with always pluralised distance message, it will now be singular for 1 mile
 
 0.24.0 / 2018-01-09
 ===================

--- a/app/lib/displayOpenResults.js
+++ b/app/lib/displayOpenResults.js
@@ -1,0 +1,5 @@
+function displayOpenResults(req) {
+  return req.query.open ? req.query.open.toLowerCase() === 'true' : false;
+}
+
+module.exports = displayOpenResults;

--- a/app/lib/resultsPageAltUrl.js
+++ b/app/lib/resultsPageAltUrl.js
@@ -1,12 +1,12 @@
 const querystring = require('querystring');
 
+const deepClone = require('./utils').deepClone;
+const displayOpenResults = require('./displayOpenResults');
 const siteRoot = require('./constants').SITE_ROOT;
 
 function resultsPageAltUrl(req) {
-  const displayOpenResults = req.query.open ? req.query.open.toLowerCase() === 'true' : false;
-
-  const query = req.query;
-  query.open = !displayOpenResults;
+  const query = deepClone(req.query);
+  query.open = !displayOpenResults(req);
   return `${siteRoot}${req.path}?${querystring.stringify(query)}`;
 }
 

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -1,0 +1,7 @@
+function deepClone(obj) {
+  return JSON.parse(JSON.stringify(obj));
+}
+
+module.exports = {
+  deepClone,
+};

--- a/app/middleware/setLocals.js
+++ b/app/middleware/setLocals.js
@@ -1,26 +1,24 @@
 const backLinkUtils = require('../lib/backLinkUtils');
 const completeOriginalUrl = require('../lib/completeOriginalUrl');
 const resultsPageAltUrl = require('../lib/resultsPageAltUrl');
+const displayOpenResults = require('../lib/displayOpenResults');
 
 function fromRequest(req, res, next) {
-  let displayOpenResults = false;
-  displayOpenResults = req.query.open ? req.query.open.toLowerCase() === 'true' : false;
-
-  res.locals.resultsPageAltUrl = resultsPageAltUrl(req);
-  res.locals.displayOpenResults = displayOpenResults;
-  res.locals.req_location = req.query.location;
-  res.locals.location = req.query.location;
-  res.locals.locationLabel = 'Enter a town, city or postcode in England';
-  res.locals.coordinates = {
-    latitude: req.query.latitude,
-    longitude: req.query.longitude,
-  };
-  res.locals.completeOriginalUrl = completeOriginalUrl(req);
   const backLink = backLinkUtils(req);
   res.locals.backLink = {
     href: backLink.url,
     text: backLink.text,
   };
+  res.locals.completeOriginalUrl = completeOriginalUrl(req);
+  res.locals.coordinates = {
+    latitude: req.query.latitude,
+    longitude: req.query.longitude,
+  };
+  res.locals.displayOpenResults = displayOpenResults(req);
+  res.locals.location = req.query.location;
+  res.locals.locationLabel = 'Enter a town, city or postcode in England';
+  res.locals.req_location = req.query.location;
+  res.locals.resultsPageAltUrl = resultsPageAltUrl(req);
   next();
 }
 

--- a/app/views/includes/result-item.nunjucks
+++ b/app/views/includes/result-item.nunjucks
@@ -1,4 +1,5 @@
-<p>{{ service.distanceInMiles | round(1) }} miles away</p>
+{% set distance = service.distanceInMiles | round(1) %}
+<p>{% if distance === 1.0 %}1 mile away{% else %}{{ distance }} miles away{% endif %}</p>
 <h2 class="results__name">{{ service.name }}</h2>
 <p>
 {% if service.address.line1 %} {{ service.address.line1 }}, {% endif %}

--- a/app/views/includes/result-item.nunjucks
+++ b/app/views/includes/result-item.nunjucks
@@ -1,35 +1,40 @@
-{% set distance = service.distanceInMiles | round(1) %}
-<p>{% if distance === 1.0 %}1 mile away{% else %}{{ distance }} miles away{% endif %}</p>
-<h2 class="results__name">{{ service.name }}</h2>
-<p>
-{% if service.address.line1 %} {{ service.address.line1 }}, {% endif %}
-{% if service.address.line2 %} {{ service.address.line2 }}, {% endif %}
-{% if service.address.line3 %} {{ service.address.line3 }}, {% endif %}
-{% if service.address.city %} {{ service.address.city }}, {% endif %}
-{% if service.address.county %} {{ service.address.county }}, {% endif %}
-{% if service.address.postcode %} {{ service.address.postcode }}<br />{% endif %}
-{% if service.contacts.telephoneNumber %}{{ service.contacts.telephoneNumber }}{% endif %}
-</p>
-<p><a href="{{service.mapUrl}}" class="results__maplink">See map and directions</a></p>
-<section class="callout callout--info callout--compact device--mobile">
-  <p class="callout--info__mesg">
-    {{ service.openingTimesMessage }}
-  </p>
-  {% if service.bankHolidayMessage %}<p class="callout callout--warning callout--compact callout--bh">{{ service.bankHolidayMessage }}</p>{% endif %}
-  <details class="" role="group">
-    <summary data-analytics="summary" role="button" aria-controls="details-content-0" aria-expanded="false">
-      <span class="details__summary">See full opening times</span>
-    </summary>
-    <div class="details__content" id="details-content-0" aria-hidden="true">
-      {% include "includes/openingTimes.nunjucks" %}
-    </div>
-  </details>
-</section>
-<section class="callout callout--info callout--compact device--tablet">
-  <p class="callout--info__mesg">
-    {{ service.openingTimesMessage }}
-  </p>
-  {% if service.bankHolidayMessage %}<p class="callout callout--warning callout--compact callout--bh">{{ service.bankHolidayMessage }}</p>{% endif %}
-    {% include "includes/openingTimes.nunjucks" %}
-</section>
-<p class="overview"><a href="{{ service.choicesOverviewUrl }}">See this pharmacy's services</a></p>
+<li class="results__item{% if service.bankHolidayMessage %} results__item--bankHoliday{% endif %}">
+  <div class="results__details column--two-thirds">
+    {% set distance = service.distanceInMiles | round(1) %}
+    <p class="distance">{% if distance === 1.0 %}1 mile away{% else %}{{ distance }} miles away{% endif %}</p>
+    <h2 class="results__name">{{ service.name }}</h2>
+    <p>
+    {% if service.address.line1 %} {{ service.address.line1 }}, {% endif %}
+    {% if service.address.line2 %} {{ service.address.line2 }}, {% endif %}
+    {% if service.address.line3 %} {{ service.address.line3 }}, {% endif %}
+    {% if service.address.city %} {{ service.address.city }}, {% endif %}
+    {% if service.address.county %} {{ service.address.county }}, {% endif %}
+    {% if service.address.postcode %} {{ service.address.postcode }}<br />{% endif %}
+    {% if service.contacts.telephoneNumber %}{{ service.contacts.telephoneNumber }}{% endif %}
+    </p>
+    <p><a href="{{service.mapUrl}}" class="results__maplink">See map and directions</a></p>
+    <section class="callout callout--info callout--compact device--mobile">
+      <p class="callout--info__mesg">
+        {{ service.openingTimesMessage }}
+      </p>
+      {% if service.bankHolidayMessage %}<p class="callout callout--warning callout--compact callout--bh">{{ service.bankHolidayMessage }}</p>{% endif %}
+      <details class="" role="group">
+        <summary data-analytics="summary" role="button" aria-controls="details-content-0" aria-expanded="false">
+          <span class="details__summary">See full opening times</span>
+        </summary>
+        <div class="details__content" id="details-content-0" aria-hidden="true">
+          {% include "includes/openingTimes.nunjucks" %}
+        </div>
+      </details>
+    </section>
+    <section class="callout callout--info callout--compact device--tablet">
+      <p class="callout--info__mesg">
+        {{ service.openingTimesMessage }}
+      </p>
+      {% if service.bankHolidayMessage %}<p class="callout callout--warning callout--compact callout--bh">{{ service.bankHolidayMessage }}</p>{% endif %}
+        {% include "includes/openingTimes.nunjucks" %}
+    </section>
+    <p class="overview"><a href="{{ service.choicesOverviewUrl }}">See this pharmacy's services</a></p>
+  </div>
+  <!--[if IE]><div style="clear: both;" class="clear-both"></div><![endif]-->
+</li>

--- a/app/views/results.nunjucks
+++ b/app/views/results.nunjucks
@@ -29,12 +29,7 @@
   <p class="viewToggle"><a class="{% if displayOpenResults %}checked{% endif %}" href="{{ resultsPageAltUrl }}">Only show pharmacies open now</a></p>
   <ol class="results">
     {% for service in services %}
-      <li class="results__item{% if service.bankHolidayMessage %} results__item--bankHoliday{% endif %}">
-        <div class="results__details column--two-thirds">
         {% include "includes/result-item.nunjucks" %}
-        </div>
-        <!--[if IE]><div style="clear: both;" class="clear-both"></div><![endif]-->
-      </li>
     {% endfor %}
   </ol>
   <p class="searchAgain"><a href="{{ SITE_ROOT }}/">Search again</a></p>

--- a/test/integration/resultsPageGeneral.js
+++ b/test/integration/resultsPageGeneral.js
@@ -1,0 +1,44 @@
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+const cheerio = require('cheerio');
+const nock = require('nock');
+const server = require('../../server');
+const constants = require('../../app/lib/constants');
+const getSampleResponse = require('../resources/getSampleResponse');
+const iExpect = require('../lib/expectations');
+
+const expect = chai.expect;
+
+chai.use(chaiHttp);
+
+const resultsRoute = `${constants.SITE_ROOT}/results`;
+
+describe('The results page', () => {
+  after('clean nock', () => {
+    nock.cleanAll();
+  });
+
+  it('should return distance away singularly for 1 mile and pluraly for other distances', (done) => {
+    const serviceApiResponse = getSampleResponse('service-api-responses/-1,54.json');
+    const location = 'Midsomer Norton, Bath and North East Somerset, BA3';
+    const latitude = 54;
+    const longitude = -1;
+    const numberOfResults = constants.api.nearbyResultsCount;
+
+    nock(process.env.API_BASE_URL)
+      .get(`/nearby?latitude=${latitude}&longitude=${longitude}&limits:results=${numberOfResults}`)
+      .times(1)
+      .reply(200, serviceApiResponse);
+
+    chai.request(server)
+      .get(resultsRoute)
+      .query({ location, latitude, longitude })
+      .end((err, res) => {
+        iExpect.htmlWith200Status(err, res);
+        const $ = cheerio.load(res.text);
+        expect($('.distance').eq(0).text()).to.equal('0 miles away');
+        expect($('.distance').eq(4).text()).to.equal('1 mile away');
+        done();
+      });
+  });
+});

--- a/test/unit/lib/displayOpenResults.js
+++ b/test/unit/lib/displayOpenResults.js
@@ -1,0 +1,31 @@
+const chai = require('chai');
+
+const displayOpenResults = require('../../../app/lib/displayOpenResults');
+
+const expect = chai.expect;
+
+describe('displayOpenResults', () => {
+  it('should return true when query contains open and it is true', () => {
+    const result = displayOpenResults({ query: { open: 'true' } });
+
+    expect(result).to.equal(true);
+  });
+
+  it('should return true when query contains open and it is TRUE', () => {
+    const result = displayOpenResults({ query: { open: 'TRUE' } });
+
+    expect(result).to.equal(true);
+  });
+
+  it('should return false when query does not contain open', () => {
+    const result = displayOpenResults({ query: { } });
+
+    expect(result).to.equal(false);
+  });
+
+  it('should return false when query contains open and it is not equal to true', () => {
+    const result = displayOpenResults({ query: { open: 'NOT true' } });
+
+    expect(result).to.equal(false);
+  });
+});


### PR DESCRIPTION
- Extracted `displayOpenResults` so it can be shared
- Reorder the setting of the locals to alphabetical to make it easier to scan through