### PR TITLE
:put_litter_in_its_place: Replace location lookups with histograms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
-0.28.1 / 2018-02-01
+0.29.0 / 2018-02-01
 ===================
 - Add desc metadata to improve description in search engines
+- Improve application instrumentation:
+  - Add postcodes.io response time monitoring
+  - Record bot traffic via `check` query string parameter
 
 0.28.0 / 2018-01-30
 ===================

--- a/app/lib/locate.js
+++ b/app/lib/locate.js
@@ -1,7 +1,5 @@
 const PostcodesIO = require('postcodesio-client');
-const placeSearches = require('../lib/promCounters').placeSearches;
-const postcodeSearches = require('../lib/promCounters').postcodeSearches;
-const myLocationSearches = require('./promCounters').myLocationSearches;
+const histograms = require('./promHistograms');
 
 // monkey patch postcodesIO to add places method
 PostcodesIO.prototype.lookupPlaces = function lookupPlaces(place, limit, callback) {
@@ -30,20 +28,23 @@ function addCountries(result) {
 }
 
 async function byPostcode(postcode) {
+  const endTimer = histograms.getPostcode.startTimer();
   const result = await postcodes.lookup(postcode);
-  postcodeSearches.inc(1);
+  endTimer();
   return addCountries(result);
 }
 
 async function byPlace(place, limit = 10) {
+  const endTimer = histograms.getPlace.startTimer();
   const result = await postcodes.lookupPlaces(place, limit);
-  placeSearches.inc(1);
+  endTimer();
   return result;
 }
 
 async function byLatLon(lat, lon) {
+  const endTimer = histograms.getReverseGeocode.startTimer();
   const result = await postcodes.reverseGeocode(lat, lon);
-  myLocationSearches.inc(1);
+  endTimer();
   return addCountries(result);
 }
 

--- a/app/lib/promCounters.js
+++ b/app/lib/promCounters.js
@@ -5,12 +5,9 @@ module.exports = {
   englishMyLocationSearches: new promClient.Counter({ name: 'english_my_location_searches', help: 'The number of my location searches in England' }),
   errorPageViews: new promClient.Counter({ name: 'error_page_views', help: 'The number of error page views' }),
   knownButNotEnglishMyLocationSearches: new promClient.Counter({ name: 'known_but_not_english_my_location_searches', help: 'The number of my location searches in an area that is known but is not in England' }),
-  myLocationSearches: new promClient.Counter({ name: 'my_location_searches', help: 'The number of my location searches' }),
   outOfAreaMyLocationSearches: new promClient.Counter({ name: 'out_of_area_my_location_searches', help: 'The number of my location searches in an unsupported area' }),
   zeroPharmacyResultsViews: new promClient.Counter({ name: 'zero_pharmacy_results_views', help: 'The number of zero pharmacy results page views' }),
   placeDisambiguationViews: new promClient.Counter({ name: 'place_disambiguation_views', help: 'The number of place disambiguation page views' }),
-  placeSearches: new promClient.Counter({ name: 'place_searches', help: 'The number of place searches' }),
-  postcodeSearches: new promClient.Counter({ name: 'postcode_searches', help: 'The number of postcode searches' }),
   zeroPlaceResultsViews: new promClient.Counter({ name: 'zero_place_results_views', help: 'The number of zero place results page views' }),
   zeroPostcodeResultsViews: new promClient.Counter({ name: 'zero_postcode_results_views', help: 'The number of zero postcode results page views' }),
 };

--- a/app/lib/promCounters.js
+++ b/app/lib/promCounters.js
@@ -6,8 +6,10 @@ module.exports = {
   errorPageViews: new promClient.Counter({ name: 'error_page_views', help: 'The number of error page views' }),
   knownButNotEnglishMyLocationSearches: new promClient.Counter({ name: 'known_but_not_english_my_location_searches', help: 'The number of my location searches in an area that is known but is not in England' }),
   outOfAreaMyLocationSearches: new promClient.Counter({ name: 'out_of_area_my_location_searches', help: 'The number of my location searches in an unsupported area' }),
-  zeroPharmacyResultsViews: new promClient.Counter({ name: 'zero_pharmacy_results_views', help: 'The number of zero pharmacy results page views' }),
   placeDisambiguationViews: new promClient.Counter({ name: 'place_disambiguation_views', help: 'The number of place disambiguation page views' }),
+  resultsCheck: new promClient.Counter({ name: 'results_check', help: 'The number of checks against the results page' }),
+  searchCheck: new promClient.Counter({ name: 'search_check', help: 'The number of checks against the search page' }),
+  zeroPharmacyResultsViews: new promClient.Counter({ name: 'zero_pharmacy_results_views', help: 'The number of zero pharmacy results page views' }),
   zeroPlaceResultsViews: new promClient.Counter({ name: 'zero_place_results_views', help: 'The number of zero place results page views' }),
   zeroPostcodeResultsViews: new promClient.Counter({ name: 'zero_postcode_results_views', help: 'The number of zero postcode results page views' }),
 };

--- a/app/lib/promHistograms.js
+++ b/app/lib/promHistograms.js
@@ -3,4 +3,7 @@ const buckets = require('./constants').promHistogramBuckets;
 
 module.exports = {
   getNearbyServices: new promClient.Histogram({ name: 'get_nearby_services', help: 'Duration histogram of request to nearby-services-api', buckets }),
+  getPostcode: new promClient.Histogram({ name: 'get_postcodes_io_postcode', help: 'Duration histogram of request to postcodes.io for postcode lookup', buckets }),
+  getPlace: new promClient.Histogram({ name: 'get_postcodes_io_place', help: 'Duration histogram of request to postcodes.io for place lookup', buckets }),
+  getReverseGeocode: new promClient.Histogram({ name: 'get_postcodes_io_reverse_geocode', help: 'Duration histogram of request to postcodes.io for reverse geocode lookup', buckets }),
 };

--- a/app/middleware/countChecks.js
+++ b/app/middleware/countChecks.js
@@ -1,0 +1,22 @@
+const counters = require('../lib/promCounters');
+
+function incrementCounter(req, next, counter) {
+  const check = req.query.check;
+  if (check === '' || check) {
+    counter.inc(1);
+  }
+  next();
+}
+
+function search(req, res, next) {
+  incrementCounter(req, next, counters.searchCheck);
+}
+
+function results(req, res, next) {
+  incrementCounter(req, next, counters.resultsCheck);
+}
+
+module.exports = {
+  search,
+  results,
+};

--- a/config/routes.js
+++ b/config/routes.js
@@ -1,21 +1,25 @@
 const router = require('express').Router();
-const locationValidator = require('../app/middleware/locationValidator');
-const getPharmacies = require('../app/middleware/getPharmacies');
+
 const coordinateResolver = require('../app/middleware/coordinateResolver');
-const renderer = require('../app/middleware/renderer');
+const countChecks = require('../app/middleware/countChecks');
+const getPharmacies = require('../app/middleware/getPharmacies');
+const locationValidator = require('../app/middleware/locationValidator');
+const logZeroResults = require('../app/middleware/logZeroResults');
 const prerender = require('../app/middleware/prerender');
+const renderer = require('../app/middleware/renderer');
 const setLocals = require('../app/middleware/setLocals');
 const setSearchType = require('../app/middleware/setSearchType');
-const logZeroResults = require('../app/middleware/logZeroResults');
 
 router.get(
   '/',
+  countChecks.search,
   setLocals.fromRequest,
   renderer.findHelp
 );
 
 router.get(
   '/results',
+  countChecks.results,
   setLocals.fromRequest,
   setSearchType,
   locationValidator,

--- a/doc/adr/0009-search-by-place.md
+++ b/doc/adr/0009-search-by-place.md
@@ -1,6 +1,6 @@
-# 9. search by place
+# 10. Count the number of checks made by bots and other automated checks
 
-Date: 2017-11-03
+Date: 2018-02-01
 
 ## Status
 
@@ -8,12 +8,17 @@ Accepted
 
 ## Context
 
-There is a need to provide the ability for users to search by place name.
+There are a lot of automated checks performed against the application. These
+checks are being counted as part of the normal traffic and there is no way to
+currently filter them out. There is a need to remove the bot traffic so real
+user behaviour can be identified.
 
 ## Decision
 
-The postcodes.io places API will be used to search for places in England.
+The decision is to count any request that includes a query string parameter `check`.
 
 ## Consequences
 
-Invalid postcodes will be treated as a place - there will no longer be an 'invalid postcode' warning.
+The number of search and result page views as a result of bot traffic will be
+able to be removed from charts showing overall activity. This will allow the
+real user behaviour to be identified.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connecting-to-services",
-  "version": "0.28.1",
+  "version": "0.29.0",
   "private": true,
   "description": "Helping to connect people to appropriate services, meeting their time, location and accessibility needs.",
   "scripts": {

--- a/test/integration/metrics.js
+++ b/test/integration/metrics.js
@@ -30,14 +30,6 @@ describe('metrics end point', () => {
     expect(responseText).to.have.string('# HELP app_starts The number of times the application has been started\n# TYPE app_starts counter');
   });
 
-  it('should return a place searches counter', () => {
-    expect(responseText).to.have.string('# HELP place_searches The number of place searches\n# TYPE place_searches counter');
-  });
-
-  it('should return a postcode searches counter', () => {
-    expect(responseText).to.have.string('# HELP postcode_searches The number of postcode searches\n# TYPE postcode_searches counter');
-  });
-
   it('should return a The number of zero pharmacy results views counter', () => {
     expect(responseText).to.have.string('# HELP zero_pharmacy_results_views The number of zero pharmacy results page views\n# TYPE zero_pharmacy_results_views counter');
   });
@@ -58,10 +50,6 @@ describe('metrics end point', () => {
     expect(responseText).to.have.string('# HELP error_page_views The number of error page views\n# TYPE error_page_views counter');
   });
 
-  it('should return an error_page_views counter', () => {
-    expect(responseText).to.have.string('# HELP error_page_views The number of error page views\n# TYPE error_page_views counter');
-  });
-
   it('should return an english_my_location_searches counter', () => {
     expect(responseText).to.have.string('# HELP english_my_location_searches The number of my location searches in England\n# TYPE english_my_location_searches counter');
   });
@@ -74,12 +62,20 @@ describe('metrics end point', () => {
     expect(responseText).to.have.string('# HELP out_of_area_my_location_searches The number of my location searches in an unsupported area\n# TYPE out_of_area_my_location_searches counter');
   });
 
-  it('should return an my_location_searches counter', () => {
-    expect(responseText).to.have.string('# HELP my_location_searches The number of my location searches\n# TYPE my_location_searches counter');
+  it('should return a histogram for get_nearby_services timings', () => {
+    expect(responseText).to.have.string('# HELP get_nearby_services Duration histogram of request to nearby-services-api\n# TYPE get_nearby_services histogram');
   });
 
-  it('should return an histogram for get_nearby_services timings', () => {
-    expect(responseText).to.have.string('# HELP get_nearby_services Duration histogram of request to nearby-services-api\n# TYPE get_nearby_services histogram');
+  it('should return a histogram for get_postcodes_io_postcode timings', () => {
+    expect(responseText).to.have.string('# HELP get_postcodes_io_postcode Duration histogram of request to postcodes.io for postcode lookup\n# TYPE get_postcodes_io_postcode histogram');
+  });
+
+  it('should return a histogram for get_postcodes_io_place timings', () => {
+    expect(responseText).to.have.string('# HELP get_postcodes_io_place Duration histogram of request to postcodes.io for place lookup\n# TYPE get_postcodes_io_place histogram');
+  });
+
+  it('should return a histogram for get_postcodes_io_reverse_geocode timings', () => {
+    expect(responseText).to.have.string('# HELP get_postcodes_io_reverse_geocode Duration histogram of request to postcodes.io for reverse geocode lookup\n# TYPE get_postcodes_io_reverse_geocode histogram');
   });
 
   it('should return an http_request_duration_seconds histogram', () => {

--- a/test/integration/metrics.js
+++ b/test/integration/metrics.js
@@ -62,6 +62,14 @@ describe('metrics end point', () => {
     expect(responseText).to.have.string('# HELP out_of_area_my_location_searches The number of my location searches in an unsupported area\n# TYPE out_of_area_my_location_searches counter');
   });
 
+  it('should return a results_check counter', () => {
+    expect(responseText).to.have.string('# HELP results_check The number of checks against the results page\n# TYPE results_check counter');
+  });
+
+  it('should return a search_check counter', () => {
+    expect(responseText).to.have.string('# HELP search_check The number of checks against the search page\n# TYPE search_check counter');
+  });
+
   it('should return a histogram for get_nearby_services timings', () => {
     expect(responseText).to.have.string('# HELP get_nearby_services Duration histogram of request to nearby-services-api\n# TYPE get_nearby_services histogram');
   });


### PR DESCRIPTION
Counts are still available. Histograms have the benefit they response
time to the external call can be monitored.