### PR TITLE
Guard against data inconsistency

### DIFF
--- a/app/lib/dateUtils.js
+++ b/app/lib/dateUtils.js
@@ -16,7 +16,7 @@ function cloneMoment(datetimeMoment, hour, minute) {
 
 function getDateTime() {
   if (process.env.DATETIME) {
-    const dateTime = moment(process.env.DATETIME, 'YYYY-MM-DD HH:mm').tz(timezone);
+    const dateTime = moment(process.env.DATETIME, 'YYYY-MM-DD HH:mm', timezone);
     if (!dateTime.isValid()) {
       throw new VError(`Invalid date: ${process.env.DATETIME}`);
     }

--- a/app/lib/handleReverseGeocodeError.js
+++ b/app/lib/handleReverseGeocodeError.js
@@ -1,7 +1,7 @@
 const log = require('../lib/logger');
 
 function handleReverseGeocodeError(error, next) {
-  log.error({ postcodeLookupResponse: { error } }, 'Reverse geocode lookup error');
+  log.error(error, 'Reverse geocode lookup error');
   next({ message: error.message, type: 'reverse-geocode-lookup-error' });
 }
 

--- a/app/lib/mappers/azContactMapper.js
+++ b/app/lib/mappers/azContactMapper.js
@@ -1,0 +1,27 @@
+const phoneNumberParser = require('../displayUtils/phoneNumberParser');
+
+function getContacts(asContacts) {
+  const contactDetails = {};
+
+  if (asContacts) {
+    const contacts = JSON.parse(asContacts);
+    contacts.forEach((c) => {
+      if (c.OrganisationContactType === 'Primary') {
+        const type = c.OrganisationContactMethodType;
+        const lowerType = type ? type.toLowerCase() : '';
+        switch (lowerType) {
+          case 'fax':
+          case 'telephone':
+            contactDetails[lowerType] = phoneNumberParser(c.OrganisationContactValue);
+            break;
+          default:
+            contactDetails[lowerType] = c.OrganisationContactValue;
+        }
+      }
+    });
+  }
+
+  return contactDetails;
+}
+
+module.exports = getContacts;

--- a/app/lib/mappers/azOpeningTimesMapper.js
+++ b/app/lib/mappers/azOpeningTimesMapper.js
@@ -12,7 +12,7 @@ function getGeneralOpeningTimes(asOpeningTimes) {
   const general = {};
   weekdays.forEach((weekday) => {
     const sessions = asOpeningTimes
-      .filter((ot) => ot.OpeningTimeType === 'General' && ot.Weekday === weekday)
+      .filter((ot) => ot.Weekday === weekday)
       .map((wot) => getTimesFromString(wot.Times));
     general[weekday.toLowerCase()] = sessions;
   });
@@ -22,7 +22,7 @@ function getGeneralOpeningTimes(asOpeningTimes) {
 function getAlterationsOpeningTimes(asOpeningTimes) {
   const alterations = {};
   asOpeningTimes
-    .filter((ot) => ot.OpeningTimeType === 'General' && ot.AdditionalOpeningDate)
+    .filter((ot) => ot.AdditionalOpeningDate)
     .forEach((aot) => {
       const aMoment = moment(aot.AdditionalOpeningDate, 'MMM DD YYYY');
       if (!alterations[aMoment.format('YYYY-MM-DD')]) {

--- a/app/lib/postcodes.js
+++ b/app/lib/postcodes.js
@@ -22,7 +22,7 @@ async function lookup(res, next) {
       next({ message: messages.invalidPostcodeMessage(location), type: 'invalid-postcode' });
     }
   } catch (e) {
-    log.error({ postcodeLookupResponse: { error: e } }, 'Postcode lookup error');
+    log.error(e, 'Postcode lookup error');
     next({ message: e.message, type: 'postcode-lookup-error' });
   }
 }

--- a/app/lib/queryBuilder.js
+++ b/app/lib/queryBuilder.js
@@ -1,4 +1,3 @@
-const moment = require('moment');
 const VError = require('verror').VError;
 const queryTypes = require('./constants').queryTypes;
 const getDateTime = require('./dateUtils').getDateTime;
@@ -6,11 +5,10 @@ const getDateTime = require('./dateUtils').getDateTime;
 const pharmacyFilter = 'OrganisationTypeID eq \'PHA\'';
 
 function getOpenPharmacyFilter(date) {
-  const aMoment = moment(date);
-  const weekday = aMoment.format('dddd');
-  const midnight = aMoment.clone().startOf('day');
-  const offsetTime = aMoment.diff(midnight, 'minutes');
-  const dateString = aMoment.format('MMM D YYYY');
+  const weekday = date.format('dddd');
+  const midnight = date.clone().startOf('day');
+  const offsetTime = date.diff(midnight, 'minutes');
+  const dateString = date.format('MMM D YYYY');
 
   // the multi-line format below is useful for legibility but not
   // needed by azure search and so is stripped out by the whitespace
@@ -23,7 +21,7 @@ function getOpenPharmacyFilter(date) {
   return `
   ${pharmacyFilter} and
   ( OpeningTimesV2/any(time:
-          and time/Weekday eq '${weekday}'
+          time/Weekday eq '${weekday}'
           and time/OpeningTimeType eq 'General'
           and time/OffsetOpeningTime le ${offsetTime}
           and time/OffsetClosingTime ge ${offsetTime})

--- a/app/lib/queryBuilder.js
+++ b/app/lib/queryBuilder.js
@@ -23,7 +23,6 @@ function getOpenPharmacyFilter(date) {
   return `
   ${pharmacyFilter} and
   ( OpeningTimesV2/any(time:
-          time/IsOpen
           and time/Weekday eq '${weekday}'
           and time/OpeningTimeType eq 'General'
           and time/OffsetOpeningTime le ${offsetTime}
@@ -33,7 +32,6 @@ function getOpenPharmacyFilter(date) {
           and time/AdditionalOpeningDate eq '${dateString}')
   ) or
   ( OpeningTimesV2/any(time:
-            time/IsOpen
             and search.in(time/OpeningTimeType, 'Additional, General')
             and time/OffsetOpeningTime le ${offsetTime}
             and time/OffsetClosingTime ge ${offsetTime}

--- a/app/lib/queryBuilder.js
+++ b/app/lib/queryBuilder.js
@@ -15,6 +15,11 @@ function getOpenPharmacyFilter(date) {
   // the multi-line format below is useful for legibility but not
   // needed by azure search and so is stripped out by the whitespace
   // replace.
+  // Note: Additional opening times can have a type of _either_ Additional or General.
+  // This is an error in the source data which seems to have been introduced in 2013
+  // and never corrected.
+  // I think that additional hours should be of type general to allow, for example,
+  // a GP surgery to have different hours on a bank holiday for reception only.
   return `
   ${pharmacyFilter} and
   ( OpeningTimesV2/any(time:
@@ -24,12 +29,12 @@ function getOpenPharmacyFilter(date) {
           and time/OffsetOpeningTime le ${offsetTime}
           and time/OffsetClosingTime ge ${offsetTime})
    and not OpeningTimesV2/any(time:
-          time/OpeningTimeType eq 'Additional'
+          search.in(time/OpeningTimeType, 'Additional, General')
           and time/AdditionalOpeningDate eq '${dateString}')
   ) or
   ( OpeningTimesV2/any(time:
             time/IsOpen
-            and time/OpeningTimeType eq 'Additional'
+            and search.in(time/OpeningTimeType, 'Additional, General')
             and time/OffsetOpeningTime le ${offsetTime}
             and time/OffsetClosingTime ge ${offsetTime}
             and time/AdditionalOpeningDate eq '${dateString}')

--- a/app/lib/queryBuilder.js
+++ b/app/lib/queryBuilder.js
@@ -32,7 +32,7 @@ function getOpenPharmacyFilter(date) {
           and time/AdditionalOpeningDate eq '${dateString}')
   ) or
   ( OpeningTimesV2/any(time:
-            and search.in(time/OpeningTimeType, 'Additional, General')
+            search.in(time/OpeningTimeType, 'Additional, General')
             and time/OffsetOpeningTime le ${offsetTime}
             and time/OffsetClosingTime ge ${offsetTime}
             and time/AdditionalOpeningDate eq '${dateString}')

--- a/app/middleware/getPharmacies.js
+++ b/app/middleware/getPharmacies.js
@@ -32,7 +32,7 @@ async function getPharmacies(req, res, next) {
         .map((org) => mapper(org, res.locals.coordinates, currentDateTime));
       next();
     } catch (error) {
-      log.error({ pharmacyLookupResponse: { error } }, 'get-pharmacies-error');
+      log.error(error, 'get-pharmacies-error');
       next('get-pharmacies-error');
     }
   } else {

--- a/app/middleware/performPlaceSearch.js
+++ b/app/middleware/performPlaceSearch.js
@@ -50,7 +50,7 @@ async function getPlaces(req, res, next) {
       renderer.places(req, res);
     }
   } catch (e) {
-    log.error({ placeLookupResponse: { error: e } }, 'Place lookup error');
+    log.error(e, 'Place lookup error');
     next({ message: e.message, type: 'place-lookup-error' });
   }
 }

--- a/test/unit/lib/mappers/azContactsMapper.js
+++ b/test/unit/lib/mappers/azContactsMapper.js
@@ -1,0 +1,92 @@
+
+/* eslint-disable sort-keys */
+const chai = require('chai');
+
+const contactMapper = require('../../../../app/lib/mappers/azContactMapper');
+
+const expect = chai.expect;
+
+describe('azContactMapper', () => {
+  it('should handle no contacts', () => {
+    const contacts = contactMapper(null);
+    expect(contacts).to.eql({});
+  });
+  it('should get telephone number when primary contact', () => {
+    const contact = {
+      OrganisationContactType: 'Primary',
+      OrganisationContactMethodType: 'Telephone',
+      OrganisationContactValue: '01904 877554',
+    };
+
+    const contacts = contactMapper(JSON.stringify([contact]));
+    expect(contacts).to.eql({ telephone: contact.OrganisationContactValue });
+  });
+  it('should get fax number when primary contact', () => {
+    const contact = {
+      OrganisationContactType: 'Primary',
+      OrganisationContactMethodType: 'Fax',
+      OrganisationContactValue: '01904 877554',
+    };
+    const contacts = contactMapper(JSON.stringify([contact]));
+    expect(contacts).to.eql({ fax: contact.OrganisationContactValue });
+  });
+  it('should get non phone contact details when primary contact', () => {
+    const contact = {
+      OrganisationContactType: 'Primary',
+      OrganisationContactMethodType: 'email',
+      OrganisationContactValue: 'pharmacist@pharmacy.co.uk',
+    };
+
+    const contacts = contactMapper(JSON.stringify([contact]));
+    expect(contacts).to.eql({ email: contact.OrganisationContactValue });
+  });
+  it('should get multiple primary contact details', () => {
+    const contact1 = {
+      OrganisationContactType: 'Primary',
+      OrganisationContactMethodType: 'Fax',
+      OrganisationContactValue: '01904 877555',
+    };
+    const contact2 = {
+      OrganisationContactType: 'Primary',
+      OrganisationContactMethodType: 'Telephone',
+      OrganisationContactValue: '01904 877444',
+    };
+    const contacts = contactMapper(JSON.stringify([contact1, contact2]));
+    expect(contacts).to.eql({
+      telephone: contact2.OrganisationContactValue,
+      fax: contact1.OrganisationContactValue,
+    });
+  });
+  it('if multiple primary contacts of same type then last one wins', () => {
+    const contact1 = {
+      OrganisationContactType: 'Primary',
+      OrganisationContactMethodType: 'Telephone',
+      OrganisationContactValue: '01904 877555',
+    };
+    const contact2 = {
+      OrganisationContactType: 'Primary',
+      OrganisationContactMethodType: 'Telephone',
+      OrganisationContactValue: '01904 877444',
+    };
+    const contacts = contactMapper(JSON.stringify([contact1, contact2]));
+    expect(contacts).to.eql({
+      telephone: contact2.OrganisationContactValue,
+    });
+  });
+  it('should ignore non primary contact details', () => {
+    const contact1 = {
+      OrganisationContactType: 'Other',
+      OrganisationContactMethodType: 'Fax',
+      OrganisationContactValue: '01904 877555',
+    };
+    const contact2 = {
+      OrganisationContactType: 'Primary',
+      OrganisationContactMethodType: 'Telephone',
+      OrganisationContactValue: '01904 877444',
+    };
+    const contacts = contactMapper(JSON.stringify([contact1, contact2]));
+    expect(contacts).to.eql({
+      telephone: contact2.OrganisationContactValue,
+    });
+  });
+});

--- a/test/unit/lib/mappers/azContactsMapper.js
+++ b/test/unit/lib/mappers/azContactsMapper.js
@@ -1,5 +1,3 @@
-
-/* eslint-disable sort-keys */
 const chai = require('chai');
 
 const contactMapper = require('../../../../app/lib/mappers/azContactMapper');
@@ -13,8 +11,8 @@ describe('azContactMapper', () => {
   });
   it('should get telephone number when primary contact', () => {
     const contact = {
-      OrganisationContactType: 'Primary',
       OrganisationContactMethodType: 'Telephone',
+      OrganisationContactType: 'Primary',
       OrganisationContactValue: '01904 877554',
     };
 
@@ -23,8 +21,8 @@ describe('azContactMapper', () => {
   });
   it('should get fax number when primary contact', () => {
     const contact = {
-      OrganisationContactType: 'Primary',
       OrganisationContactMethodType: 'Fax',
+      OrganisationContactType: 'Primary',
       OrganisationContactValue: '01904 877554',
     };
     const contacts = contactMapper(JSON.stringify([contact]));
@@ -32,8 +30,8 @@ describe('azContactMapper', () => {
   });
   it('should get non phone contact details when primary contact', () => {
     const contact = {
-      OrganisationContactType: 'Primary',
       OrganisationContactMethodType: 'email',
+      OrganisationContactType: 'Primary',
       OrganisationContactValue: 'pharmacist@pharmacy.co.uk',
     };
 
@@ -42,30 +40,30 @@ describe('azContactMapper', () => {
   });
   it('should get multiple primary contact details', () => {
     const contact1 = {
-      OrganisationContactType: 'Primary',
       OrganisationContactMethodType: 'Fax',
+      OrganisationContactType: 'Primary',
       OrganisationContactValue: '01904 877555',
     };
     const contact2 = {
-      OrganisationContactType: 'Primary',
       OrganisationContactMethodType: 'Telephone',
+      OrganisationContactType: 'Primary',
       OrganisationContactValue: '01904 877444',
     };
     const contacts = contactMapper(JSON.stringify([contact1, contact2]));
     expect(contacts).to.eql({
-      telephone: contact2.OrganisationContactValue,
       fax: contact1.OrganisationContactValue,
+      telephone: contact2.OrganisationContactValue,
     });
   });
   it('if multiple primary contacts of same type then last one wins', () => {
     const contact1 = {
-      OrganisationContactType: 'Primary',
       OrganisationContactMethodType: 'Telephone',
+      OrganisationContactType: 'Primary',
       OrganisationContactValue: '01904 877555',
     };
     const contact2 = {
-      OrganisationContactType: 'Primary',
       OrganisationContactMethodType: 'Telephone',
+      OrganisationContactType: 'Primary',
       OrganisationContactValue: '01904 877444',
     };
     const contacts = contactMapper(JSON.stringify([contact1, contact2]));
@@ -75,13 +73,13 @@ describe('azContactMapper', () => {
   });
   it('should ignore non primary contact details', () => {
     const contact1 = {
-      OrganisationContactType: 'Other',
       OrganisationContactMethodType: 'Fax',
+      OrganisationContactType: 'Other',
       OrganisationContactValue: '01904 877555',
     };
     const contact2 = {
-      OrganisationContactType: 'Primary',
       OrganisationContactMethodType: 'Telephone',
+      OrganisationContactType: 'Primary',
       OrganisationContactValue: '01904 877444',
     };
     const contacts = contactMapper(JSON.stringify([contact1, contact2]));

--- a/test/unit/lib/queryBuilder.js
+++ b/test/unit/lib/queryBuilder.js
@@ -10,15 +10,15 @@ describe('queryBuilder', () => {
   const searchOrigin = { latitude: 53.234149, longitude: 5.024449 };
   describe('nearby and open', () => {
     let query;
-    afterEach('set dateTime override', () => {
+    afterEach('reset dateTime override', () => {
       delete process.env.DATETIME;
     });
-    beforeEach('reset dateTime override', () => {
-      process.env.DATETIME = '2019-10-03';
+    beforeEach('set dateTime override', () => {
+      process.env.DATETIME = '2019-10-03 09:00';
       query = queryBuilder(searchOrigin, { queryType: queryTypes.openNearby });
     });
     it('should return filter', () => {
-      const expectedFilter = " OrganisationTypeID eq 'PHA' and ( OpeningTimesV2/any(time: and time/Weekday eq 'Thursday' and time/OpeningTimeType eq 'General' and time/OffsetOpeningTime le 0 and time/OffsetClosingTime ge 0) and not OpeningTimesV2/any(time: search.in(time/OpeningTimeType, 'Additional, General') and time/AdditionalOpeningDate eq 'Oct 3 2019') ) or ( OpeningTimesV2/any(time: search.in(time/OpeningTimeType, 'Additional, General') and time/OffsetOpeningTime le 0 and time/OffsetClosingTime ge 0 and time/AdditionalOpeningDate eq 'Oct 3 2019') )";
+      const expectedFilter = " OrganisationTypeID eq 'PHA' and ( OpeningTimesV2/any(time: time/Weekday eq 'Thursday' and time/OpeningTimeType eq 'General' and time/OffsetOpeningTime le 540 and time/OffsetClosingTime ge 540) and not OpeningTimesV2/any(time: search.in(time/OpeningTimeType, 'Additional, General') and time/AdditionalOpeningDate eq 'Oct 3 2019') ) or ( OpeningTimesV2/any(time: search.in(time/OpeningTimeType, 'Additional, General') and time/OffsetOpeningTime le 540 and time/OffsetClosingTime ge 540 and time/AdditionalOpeningDate eq 'Oct 3 2019') )";
 
       expect(query.filter).to.equal(expectedFilter);
     });

--- a/test/unit/lib/queryBuilder.js
+++ b/test/unit/lib/queryBuilder.js
@@ -1,0 +1,70 @@
+const chai = require('chai');
+const VError = require('verror').VError;
+
+const queryBuilder = require('../../../app/lib/queryBuilder');
+const queryTypes = require('../../../app/lib/constants').queryTypes;
+
+const expect = chai.expect;
+
+describe('queryBuilder', () => {
+  const searchOrigin = { latitude: 53.234149, longitude: 5.024449 };
+  describe('nearby and open', () => {
+    let query;
+    afterEach('set dateTime override', () => {
+      delete process.env.DATETIME;
+    });
+    beforeEach('reset dateTime override', () => {
+      process.env.DATETIME = '2019-10-03';
+      query = queryBuilder(searchOrigin, { queryType: queryTypes.openNearby });
+    });
+    it('should return filter', () => {
+      const expectedFilter = " OrganisationTypeID eq 'PHA' and ( OpeningTimesV2/any(time: and time/Weekday eq 'Thursday' and time/OpeningTimeType eq 'General' and time/OffsetOpeningTime le 0 and time/OffsetClosingTime ge 0) and not OpeningTimesV2/any(time: search.in(time/OpeningTimeType, 'Additional, General') and time/AdditionalOpeningDate eq 'Oct 3 2019') ) or ( OpeningTimesV2/any(time: search.in(time/OpeningTimeType, 'Additional, General') and time/OffsetOpeningTime le 0 and time/OffsetClosingTime ge 0 and time/AdditionalOpeningDate eq 'Oct 3 2019') )";
+
+      expect(query.filter).to.equal(expectedFilter);
+    });
+    it('should return orderby', () => {
+      expect(query.orderby).to.equal(`geo.distance(Geocode, geography'POINT(${searchOrigin.longitude} ${searchOrigin.latitude})')`);
+    });
+    it('should return select', () => {
+      expect(query.select).to.not.be.empty;
+    });
+  });
+  describe('nearby', () => {
+    it('should return filter', () => {
+      const query = queryBuilder(searchOrigin, { queryType: queryTypes.nearby });
+      expect(query).to.not.be.undefined;
+      expect(query.filter).to.equal('OrganisationTypeID eq \'PHA\'');
+      expect(query.orderby).to.not.be.undefined;
+      expect(query.top).to.equal(10);
+    });
+    it('should return orderby', () => {
+      const query = queryBuilder(searchOrigin, { queryType: queryTypes.nearby });
+      expect(query).to.not.be.undefined;
+      expect(query.orderby).to.equal(`geo.distance(Geocode, geography'POINT(${searchOrigin.longitude} ${searchOrigin.latitude})')`);
+    });
+    it('should return select', () => {
+      const query = queryBuilder(searchOrigin, { queryType: queryTypes.nearby });
+      expect(query.select).to.not.be.empty;
+    });
+    it('should return count', () => {
+      const query = queryBuilder(searchOrigin, { queryType: queryTypes.nearby });
+      expect(query.count).to.be.true;
+    });
+    it('should return default top', () => {
+      const query = queryBuilder(searchOrigin, { queryType: queryTypes.nearby });
+      expect(query.top).to.equal(10);
+    });
+    it('should return specified top', () => {
+      const query = queryBuilder(searchOrigin, {
+        queryType: queryTypes.nearby,
+        size: 15,
+      });
+      expect(query.top).to.equal(15);
+    });
+  });
+  describe('error', () => {
+    it('should throw for unknown queryType', () => {
+      expect(() => queryBuilder(searchOrigin, { queryType: 'unknown' })).to.throw(VError, 'Unknown queryType: unknown');
+    });
+  });
+});


### PR DESCRIPTION
Additional opening times for phamacies (and possibly other org types)
can have a type of _either_ Additional or General.  This is an error in
the source data which seems to have been introduced in 2013 and never
corrected.  We have extended the guard rather than remove it (since
'additionalness' can be infered by a non-zero AdditionalOpeningDate) to
filter out any future opening times for different types (e.g. reception)