### PR TITLE
Query was returning all orgs open on a bank holiday

### DIFF
--- a/app/lib/queryBuilder.js
+++ b/app/lib/queryBuilder.js
@@ -20,7 +20,7 @@ function getOpenPharmacyFilter(date) {
   // a GP surgery to have different hours on a bank holiday for reception only.
   return `
   ( ${pharmacyFilter} ) and
-  ( OpeningTimesV2/any(time:
+  ( ( OpeningTimesV2/any(time:
           time/Weekday eq '${weekday}'
           and time/OpeningTimeType eq 'General'
           and time/OffsetOpeningTime le ${offsetTime}
@@ -34,7 +34,7 @@ function getOpenPharmacyFilter(date) {
             and time/OffsetOpeningTime le ${offsetTime}
             and time/OffsetClosingTime ge ${offsetTime}
             and time/AdditionalOpeningDate eq '${dateString}')
-  )`.replace(/\s+/g, ' ');
+  ) )`.replace(/\s+/g, ' ');
 }
 
 function build(searchOrigin, options) {

--- a/test/unit/lib/queryBuilder.js
+++ b/test/unit/lib/queryBuilder.js
@@ -19,7 +19,7 @@ describe('queryBuilder', () => {
       query = queryBuilder(searchOrigin, { queryType: queryTypes.openNearby });
     });
     it('should return filter', () => {
-      const expectedFilter = ` ( ${expectedPharamcyFilter} ) and ( OpeningTimesV2/any(time: time/Weekday eq 'Thursday' and time/OpeningTimeType eq 'General' and time/OffsetOpeningTime le 540 and time/OffsetClosingTime ge 540) and not OpeningTimesV2/any(time: search.in(time/OpeningTimeType, 'Additional, General') and time/AdditionalOpeningDate eq 'Oct 3 2019') ) or ( OpeningTimesV2/any(time: search.in(time/OpeningTimeType, 'Additional, General') and time/OffsetOpeningTime le 540 and time/OffsetClosingTime ge 540 and time/AdditionalOpeningDate eq 'Oct 3 2019') )`;
+      const expectedFilter = ` ( ${expectedPharamcyFilter} ) and ( ( OpeningTimesV2/any(time: time/Weekday eq 'Thursday' and time/OpeningTimeType eq 'General' and time/OffsetOpeningTime le 540 and time/OffsetClosingTime ge 540) and not OpeningTimesV2/any(time: search.in(time/OpeningTimeType, 'Additional, General') and time/AdditionalOpeningDate eq 'Oct 3 2019') ) or ( OpeningTimesV2/any(time: search.in(time/OpeningTimeType, 'Additional, General') and time/OffsetOpeningTime le 540 and time/OffsetClosingTime ge 540 and time/AdditionalOpeningDate eq 'Oct 3 2019') ) )`;
 
       expect(query.filter).to.equal(expectedFilter);
     });


### PR DESCRIPTION
The query logic was using the default precedance (which was wrong)
and was return all orgs which were open as a result of additional
hours regardless of org type.